### PR TITLE
Fix birth time conversion and refine coordinates

### DIFF
--- a/backend/birth_info.py
+++ b/backend/birth_info.py
@@ -1,15 +1,23 @@
 import swisseph as swe
 from datetime import datetime
+import pytz
 
 def get_birth_info(date, time, latitude, longitude, timezone):
     """
     Compute Julian Day, sidereal offset, ascendant, house cusps.
     Returns a dict with jd_ut, sidereal_offset, asc, houses.
     """
-    # combine date and time to UTC datetime
-    dt = datetime.combine(date, time)
-    # convert to Julian Day UTC
-    jd_ut = swe.julday(dt.year, dt.month, dt.day, dt.hour + dt.minute/60 + dt.second/3600)
+    # combine date and time and convert to UTC based on the given timezone
+    tz = pytz.timezone(timezone)
+    local_dt = tz.localize(datetime.combine(date, time))
+    utc_dt = local_dt.astimezone(pytz.utc)
+    # convert the UTC datetime to Julian Day
+    jd_ut = swe.julday(
+        utc_dt.year,
+        utc_dt.month,
+        utc_dt.day,
+        utc_dt.hour + utc_dt.minute / 60 + utc_dt.second / 3600,
+    )
     # set sidereal ayanamsha (Fagan/Bradley)
     swe.set_sid_mode(swe.SIDM_FAGAN_BRADLEY)
     # compute houses and ascendant

--- a/src/components/BasicInfo.jsx
+++ b/src/components/BasicInfo.jsx
@@ -23,7 +23,10 @@ export default function BasicInfo({ birth }) {
       )}
       <p>
         <strong>Coordinates:</strong>{" "}
-        {birth.latitude.toFixed(2)}°, {birth.longitude.toFixed(2)}°
+        {Math.abs(birth.latitude).toFixed(4)}°{" "}
+        {birth.latitude >= 0 ? "N" : "S"},{" "}
+        {Math.abs(birth.longitude).toFixed(4)}°{" "}
+        {birth.longitude >= 0 ? "E" : "W"}
       </p>
       <p>
         <strong>Timezone:</strong> {birth.timezone}


### PR DESCRIPTION
## Summary
- compute birth Julian Day using timezone-aware UTC time
- display birth coordinates with 4 decimal precision and cardinal directions

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7039b1908320a81ca608be8a4085