### PR TITLE
Add CoreElements component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css';
 import ProfileForm from './components/ProfileForm';
 import BasicInfo from './components/BasicInfo';
 import ProfileSummary from './components/ProfileSummary';
+import CoreElements from './components/CoreElements';
 import PlanetTable from './components/PlanetTable';
 import DashaTable from './components/DashaTable';
 import HouseAnalysis from './components/HouseAnalysis';
@@ -155,6 +156,10 @@ function App() {
             }}
           />
           <ProfileSummary analysis={profile.analysis} />
+          <CoreElements
+            analysis={profile.analysis}
+            elements={profile.coreElements}
+          />
           <PlanetTable planets={profile.planetaryPositions} />
           <HouseAnalysis houses={profile.houses} />
           <DashaTable dasha={profile.vimshottariDasha} />

--- a/src/components/CoreElements.jsx
+++ b/src/components/CoreElements.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default function CoreElements({ analysis, elements }) {
+  const data =
+    (analysis && (analysis.coreElements || analysis.core_elements)) ||
+    elements;
+
+  if (!data || typeof data !== 'object') return null;
+
+  const entries = Object.entries(data);
+  if (entries.length === 0) return null;
+
+  const formatPercent = val => {
+    if (typeof val === 'number') return val.toString();
+    const m = String(val).match(/([0-9]+(?:\.[0-9]+)?)/);
+    return m ? m[1] : String(val);
+  };
+
+  return (
+    <section className="mb-6">
+      <h3>Core Elements</h3>
+      <ul>
+        {entries.map(([elem, val]) => (
+          <li key={elem}>
+            <strong>{elem}:</strong> {formatPercent(val)}%
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/CoreElements.test.jsx
+++ b/src/components/CoreElements.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import CoreElements from './CoreElements';
+
+const sample = { Fire: 40, Earth: 30, Air: 20, Water: 10 };
+
+test('renders elemental percentages', () => {
+  render(<CoreElements elements={sample} />);
+  const item = screen.getByText(
+    (_, node) => node.textContent === 'Fire: 40%'
+  );
+  expect(item).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- render elemental balance with new `CoreElements` component
- display the component in `App`
- test core element rendering

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e70e688c08320a7a034952377b3a6