### PR TITLE
Add dasha chart visualization

### DIFF
--- a/backend/birth_info.py
+++ b/backend/birth_info.py
@@ -20,11 +20,14 @@ def get_birth_info(date, time, latitude, longitude, timezone):
     )
     # set sidereal ayanamsha (Fagan/Bradley)
     swe.set_sid_mode(swe.SIDM_FAGAN_BRADLEY)
+    # get ayanamsa (sidereal offset)
+    sidereal_offset = swe.get_ayanamsa(jd_ut)
     # compute houses and ascendant
     cusps, ascmc = swe.houses(jd_ut, latitude, longitude)
     asc = ascmc[0]
     return {
         "jd_ut": jd_ut,
+        "sidereal_offset": sidereal_offset,
         "ascendant": asc,
         "cusps": cusps,
         "latitude": latitude,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,12 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
+        "chart.js": "^4.5.0",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "date-fns": "^3.6.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
         "web-vitals": "^3.1.0"
       },
@@ -792,6 +796,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
@@ -1618,6 +1628,28 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1720,6 +1752,23 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/concurrently/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/concurrently/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1792,20 +1841,13 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -3452,6 +3494,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "web-vitals": "^3.1.0"
+    "web-vitals": "^3.1.0",
+    "chart.js": "^4.5.0",
+    "react-chartjs-2": "^5.3.0",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "date-fns": "^3.6.0"
   },
   "overrides": {
     "@svgr/webpack": "^8.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import ProfileSummary from './components/ProfileSummary';
 import CoreElements from './components/CoreElements';
 import PlanetTable from './components/PlanetTable';
 import DashaTable from './components/DashaTable';
+import DashaChart from './components/DashaChart';
 import HouseAnalysis from './components/HouseAnalysis';
 
 function App() {
@@ -163,6 +164,7 @@ function App() {
           <PlanetTable planets={profile.planetaryPositions} />
           <HouseAnalysis houses={profile.houses} />
           <DashaTable dasha={profile.vimshottariDasha} />
+          <DashaChart dasha={profile.vimshottariDasha} />
         </section>
       )}
     </div>

--- a/src/components/DashaChart.jsx
+++ b/src/components/DashaChart.jsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  TimeScale,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import 'chartjs-adapter-date-fns';
+
+Chart.register(LineElement, PointElement, LinearScale, TimeScale, Tooltip, Legend);
+
+export default function DashaChart({ dasha }) {
+  const data = useMemo(() => {
+    if (!Array.isArray(dasha) || dasha.length === 0) return null;
+    return {
+      datasets: dasha.map((d, idx) => ({
+        label: d.lord,
+        data: [
+          { x: new Date(d.start), y: idx },
+          { x: new Date(d.end), y: idx },
+        ],
+        borderWidth: 4,
+        fill: false,
+      })),
+    };
+  }, [dasha]);
+
+  if (!data) return null;
+
+  const options = {
+    scales: {
+      y: {
+        ticks: {
+          callback: (_, i) => (dasha && dasha[i] ? dasha[i].lord : i),
+        },
+        beginAtZero: false,
+      },
+      x: { type: 'time' },
+    },
+    plugins: { legend: { display: false } },
+  };
+
+  return (
+    <section className="mb-6">
+      <h3>Dasha Timeline</h3>
+      <Line data={data} options={options} />
+    </section>
+  );
+}

--- a/src/components/DashaChart.test.jsx
+++ b/src/components/DashaChart.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import DashaChart from './DashaChart';
+
+const sample = [
+  { lord: 'Sun', start: '2020-01-01', end: '2021-01-01' },
+  { lord: 'Moon', start: '2021-01-01', end: '2022-01-01' },
+];
+
+test('renders dasha chart heading', () => {
+  render(<DashaChart dasha={sample} />);
+  expect(screen.getByText(/dasha timeline/i)).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- compute sidereal offset in `get_birth_info`
- visualize Vimshottari dasha periods
- include new chart component in the app
- install chart.js and related packages
- test `DashaChart` rendering

## Testing
- `npm test`
- `PYTHONPATH=. python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e75236050832092e6abe160c2bff0