### PR TITLE
Improve error feedback when server returns empty body

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,6 +103,12 @@ function App() {
           setError(payload.detail);
         } else if (typeof payload === 'string') {
           setError(payload || res.statusText);
+        } else if (
+          payload &&
+          typeof payload === 'object' &&
+          Object.keys(payload).length === 0
+        ) {
+          setError(res.statusText || 'Unknown error');
         } else {
           setError(JSON.stringify(payload, null, 2));
         }


### PR DESCRIPTION
## Summary
- handle empty object responses in client API error handler

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea186a60c8320a5e7da4295e36f6d