### PR TITLE
Expand tests and add CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m venv backend/venv
+      - run: backend/venv/bin/pip install -r backend/requirements.txt
+      - run: backend/venv/bin/pip install pytest
+      - run: PYTHONPATH=. backend/venv/bin/pytest -q

--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ PYTHONPATH=. pytest -q
 ```
 
 The backend tests stub all external dependencies so no API keys or internet access are required.
+
+## Continuous integration
+
+Automated tests run on GitHub Actions for every push and pull request. The workflow installs Node and Python dependencies and executes both the frontend and backend test suites.

--- a/src/components/ProfileForm.test.jsx
+++ b/src/components/ProfileForm.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import ProfileForm from './ProfileForm';
+
+const filled = { name: 'Test', birthDate: '2000-01-01', birthTime: '12:00', location: 'Delhi' };
+
+test('handles input and submit', () => {
+  const handleChange = vi.fn();
+  const handleSubmit = vi.fn(e => e.preventDefault());
+  render(<ProfileForm form={filled} onChange={handleChange} onSubmit={handleSubmit} loading={false} />);
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'New' } });
+  expect(handleChange).toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(handleSubmit).toHaveBeenCalled();
+});

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,56 @@
+from backend.analysis import (
+    interpret_nakshatra,
+    interpret_houses,
+    interpret_core_elements,
+    interpret_dasha_sequence,
+    interpret_divisional_charts,
+    full_analysis,
+)
+
+
+def test_interpret_nakshatra():
+    res = interpret_nakshatra({'nakshatra': 'Ashwini', 'pada': 1})
+    assert res['nakshatra'] == 'Ashwini'
+    assert res['pada'] == 1
+    assert 'Healing' in res['description']
+
+
+def test_interpret_houses():
+    mapping = {1: ['Sun'], 2: []}
+    res = interpret_houses(mapping)
+    assert 'Sun' in res[1]
+    assert 'no major planets' in res[2]
+
+
+def test_interpret_core_elements():
+    res = interpret_core_elements({'Fire': 60})
+    assert res['Fire'].startswith('Fire: 60%')
+
+
+def test_interpret_dasha_sequence():
+    dashas = [{'lord': 'Sun', 'start': '2020', 'end': '2021'}]
+    res = interpret_dasha_sequence(dashas)
+    assert res[0]['lord'] == 'Sun'
+    assert 'vitality' in res[0]['description'].lower()
+
+
+def test_interpret_divisional_charts():
+    charts = {'D1': {'Sun': 1, 'Moon': 1}}
+    res = interpret_divisional_charts(charts)
+    assert 'D1' in res
+    assert res['D1']['distribution'][1] == 2
+
+
+def test_full_analysis():
+    planets = [{'name': 'Sun', 'longitude': 10.0}]
+    dashas = [{'lord': 'Sun', 'start': '2020', 'end': '2021'}]
+    nak = {'nakshatra': 'Ashwini', 'pada': 1}
+    houses = {1: ['Sun']}
+    core = {'Fire': 60}
+    dcharts = {'D1': {'Sun': 1}}
+    out = full_analysis(planets, dashas, nak, houses, core, dcharts)
+    assert 'nakshatra' in out
+    assert 'houses' in out
+    assert 'coreElements' in out
+    assert 'vimshottariDasha' in out
+    assert 'divisionalCharts' in out


### PR DESCRIPTION
## Summary
- add unit tests for backend analysis helpers
- add a ProfileForm component test
- configure GitHub Actions to run both test suites
- document the new CI workflow

## Testing
- `npm test`
- `PYTHONPATH=. backend/venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea5fa9c18832083699dd604b9d903