### PR TITLE
Add ayanamsha and house options

### DIFF
--- a/backend/birth_info.py
+++ b/backend/birth_info.py
@@ -2,13 +2,44 @@ import swisseph as swe
 from datetime import datetime
 import pytz
 
-def get_birth_info(date, time, latitude, longitude, timezone):
+# Mapping of human readable ayanamsha names to Swiss Ephemeris constants
+AYANAMSHA_MAP = {
+    "fagan": swe.SIDM_FAGAN_BRADLEY,
+    "fagan/bradley": swe.SIDM_FAGAN_BRADLEY,
+    "lahiri": swe.SIDM_LAHIRI,
+    "raman": swe.SIDM_RAMAN,
+    "krishnamurti": swe.SIDM_KRISHNAMURTI,
+}
+
+def get_birth_info(
+    date,
+    time,
+    latitude,
+    longitude,
+    timezone,
+    *,
+    ayanamsha: str | int = "fagan",
+    house_system: str = "P",
+):
+    """Return core astronomical info for a birth.
+
+    Parameters are validated and then fed to Swiss Ephemeris. ``ayanamsha`` can
+    be a human readable name like ``"lahiri"`` or one of the numeric constants
+    from :mod:`swisseph`. ``house_system`` is the single letter code understood
+    by :func:`swisseph.houses`.
     """
-    Compute Julian Day, sidereal offset, ascendant, house cusps.
-    Returns a dict with jd_ut, sidereal_offset, asc, houses.
-    """
-    # combine date and time and convert to UTC based on the given timezone
-    tz = pytz.timezone(timezone)
+    # validate coordinates
+    if not (-90.0 <= latitude <= 90.0):
+        raise ValueError("Latitude must be between -90 and 90 degrees")
+    if not (-180.0 <= longitude <= 180.0):
+        raise ValueError("Longitude must be between -180 and 180 degrees")
+
+    # validate timezone
+    try:
+        tz = pytz.timezone(timezone)
+    except pytz.UnknownTimeZoneError as exc:
+        raise ValueError(f"Invalid timezone '{timezone}'") from exc
+
     local_dt = tz.localize(datetime.combine(date, time))
     utc_dt = local_dt.astimezone(pytz.utc)
     # convert the UTC datetime to Julian Day
@@ -18,12 +49,21 @@ def get_birth_info(date, time, latitude, longitude, timezone):
         utc_dt.day,
         utc_dt.hour + utc_dt.minute / 60 + utc_dt.second / 3600,
     )
-    # set sidereal ayanamsha (Fagan/Bradley)
-    swe.set_sid_mode(swe.SIDM_FAGAN_BRADLEY)
+
+    # determine ayanamsha constant
+    if isinstance(ayanamsha, str):
+        ay_const = AYANAMSHA_MAP.get(ayanamsha.lower())
+        if ay_const is None:
+            raise ValueError(f"Unknown ayanamsha '{ayanamsha}'")
+    else:
+        ay_const = int(ayanamsha)
+
+    swe.set_sid_mode(ay_const)
     # get ayanamsa (sidereal offset)
     sidereal_offset = swe.get_ayanamsa(jd_ut)
     # compute houses and ascendant
-    cusps, ascmc = swe.houses(jd_ut, latitude, longitude)
+    hsys = house_system.upper().encode()
+    cusps, ascmc = swe.houses(jd_ut, latitude, longitude, hsys)
     asc = ascmc[0]
     return {
         "jd_ut": jd_ut,


### PR DESCRIPTION
## Summary
- allow choosing ayanamsha and house system when computing birth info
- validate coordinates and timezone
- cover new birth info features with tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb28e77bc83209304d0ababa102e2