### PR TITLE
Standardize ayanamsha naming

### DIFF
--- a/backend/birth_info.py
+++ b/backend/birth_info.py
@@ -3,7 +3,8 @@ from datetime import datetime
 import pytz
 
 
-AYANAMSA_MAP = {
+# Supported ayanamśa options
+AYANAMSHA_MAP = {
     "fagan_bradley": swe.SIDM_FAGAN_BRADLEY,
     "lahiri": swe.SIDM_LAHIRI,
     "raman": swe.SIDM_RAMAN,
@@ -16,7 +17,7 @@ HOUSE_MAP = {
 }
 
 def get_birth_info(date, time, latitude, longitude, timezone,
-                   *, ayanamsa: str = "fagan_bradley",
+                   *, ayanamsha: str = "fagan_bradley",
                    house_system: str = "placidus"):
     """
     Compute Julian Day, sidereal offset, ascendant, house cusps.

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ConfigDict
+from typing import Literal
 
 from backend.config import load_config
 from backend.geocoder import geocode_location
@@ -58,9 +59,15 @@ class ProfileRequest(BaseModel):
     birth_date: dt_date = Field(..., alias="date")
     birth_time: dt_time = Field(..., alias="time")
     location: str = Field(...)
-    ayanamsa: str = Field(default=CONFIG.get("ayanamsa", "fagan_bradley"))
-    node_type: str = Field(default=CONFIG.get("node_type", "mean"), alias="lunar_node")
-    house_system: str = Field(default=CONFIG.get("house_system", "placidus"))
+    ayanamsa: Literal["fagan_bradley", "lahiri", "raman", "kp"] = Field(
+        default=CONFIG.get("ayanamsa", "fagan_bradley")
+    )
+    node_type: Literal["mean", "true"] = Field(
+        default=CONFIG.get("node_type", "mean"), alias="lunar_node"
+    )
+    house_system: Literal["placidus", "whole_sign"] = Field(
+        default=CONFIG.get("house_system", "placidus")
+    )
 
 
 def _compute_profile(request: ProfileRequest):
@@ -80,7 +87,7 @@ def _compute_profile(request: ProfileRequest):
         latitude=lat,
         longitude=lon,
         timezone=tz,
-        ayanamsa=request.ayanamsa,
+        ayanamsha=request.ayanamsa,
         house_system=request.house_system,
     )
     planets = calculate_planets(binfo, node_type=request.node_type)


### PR DESCRIPTION
## Summary
- tidy up ayanamsha constant and parameter names
- validate config options using Literal types

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee9ed33188320870474a197c3210f