### PR TITLE
Fix house system option handling

### DIFF
--- a/backend/birth_info.py
+++ b/backend/birth_info.py
@@ -59,7 +59,20 @@ def get_birth_info(date, time, latitude, longitude, timezone,
     # get ayanamsa (sidereal offset)
     sidereal_offset = swe.get_ayanamsa(jd_ut)
     # compute houses and ascendant
-    hsys = house_system.upper().encode()
+    # SwissEph expects a single character identifying the house system.
+    # Map the user-friendly name to the correct byte code, defaulting to
+    # Placidus if the provided option is unknown.
+    # Users may pass the single-letter code directly (e.g. "P" or "W")
+    # or a full name like "placidus". Normalize both cases.
+    if isinstance(house_system, bytes):
+        hsys = house_system[:1]
+    else:
+        key = house_system.lower()
+        hsys = HOUSE_MAP.get(key)
+        if not hsys and len(house_system) == 1:
+            hsys = house_system.upper().encode()[:1]
+    if not hsys:
+        hsys = b"P"
     cusps, ascmc = swe.houses(jd_ut, latitude, longitude, hsys)
     asc = ascmc[0]
     return {


### PR DESCRIPTION
## Summary
- normalize `house_system` to support full names or single-letter codes
- pass single-character code to `swisseph.houses`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef04237808320a93a9cb6f11f680c