### PR TITLE
Extend house analysis

### DIFF
--- a/backend/house_analysis.py
+++ b/backend/house_analysis.py
@@ -1,22 +1,86 @@
-def analyze_houses(binfo, planets):
-    """
-    Determine which planets fall into which houses.
-    Returns dict mapping house number to list of planet names.
-    """
-    cusps = binfo['cusps']
-    analysis = {i: [] for i in range(1,13)}
+import swisseph as swe
+from .birth_info import HOUSE_MAP
+
+# Relative houses each planet aspects by graha drishti
+_ASPECT_PATTERNS = {
+    "Mars": [4, 7, 8],
+    "Jupiter": [5, 7, 9],
+    "Saturn": [3, 7, 10],
+}
+
+
+def _normalize_house_system(house_system):
+    """Return SwissEph house system code from a friendly name or byte."""
+    if house_system is None:
+        return None
+    if isinstance(house_system, bytes):
+        return house_system[:1]
+    key = house_system.lower()
+    code = HOUSE_MAP.get(key)
+    if not code and len(house_system) == 1:
+        code = house_system.upper().encode()[:1]
+    return code or b"P"
+
+
+def _get_cusps(binfo, house_system=None):
+    """Compute cusps for the given house system or use precomputed ones."""
+    if house_system is None:
+        return binfo["cusps"]
+    hsys = _normalize_house_system(house_system)
+    cusps, _ = swe.houses(
+        binfo["jd_ut"], binfo["latitude"], binfo["longitude"], hsys
+    )
+    return cusps
+
+
+def _planet_house(lon, cusps):
+    """Determine which house a longitude falls into handling cusp edges."""
+    # If exactly on a cusp, assign to the following house
+    for idx, cusp in enumerate(cusps):
+        if abs((lon - cusp) % 360) < 1e-6:
+            return idx + 1
+    for i in range(1, 13):
+        start = cusps[i - 1]
+        end = cusps[i % 12]
+        if start < end:
+            if start < lon < end:
+                return i
+        else:  # wrap-around
+            if lon > start or lon < end:
+                return i
+    return 12
+
+
+def _aspected_houses(name, house):
+    rel = _ASPECT_PATTERNS.get(name, [7])
+    return [((house + r - 2) % 12) + 1 for r in rel]
+
+
+def _calculate_aspects(placements):
+    aspects = {n: _aspected_houses(n, info["house"]) for n, info in placements.items()}
+    mutual = []
+    names = list(placements)
+    for i, n1 in enumerate(names):
+        for n2 in names[i + 1 :]:
+            if (
+                placements[n2]["house"] in aspects[n1]
+                and placements[n1]["house"] in aspects[n2]
+            ):
+                pair = tuple(sorted((n1, n2)))
+                mutual.append(pair)
+    return {"planet_aspects": aspects, "mutual_aspects": mutual}
+
+
+def analyze_houses(binfo, planets, *, house_system=None):
+    """Return house occupancy, individual placements and aspect info."""
+    cusps = _get_cusps(binfo, house_system)
+    houses = {i: [] for i in range(1, 13)}
+    placements = {}
     for p in planets:
-        lon = p['longitude']
-        # find house by comparing to cusps
-        for i in range(1,13):
-            start = cusps[i-1]
-            end = cusps[i % 12]
-            if start < end:
-                if start <= lon < end:
-                    analysis[i].append(p['name'])
-                    break
-            else:  # wrap-around
-                if lon >= start or lon < end:
-                    analysis[i].append(p['name'])
-                    break
-    return analysis
+        lon = p["longitude"]
+        house = _planet_house(lon, cusps)
+        houses[house].append(p["name"])
+        placements[p["name"]] = {"sign": p.get("sign") or int(lon // 30) + 1, "house": house}
+
+    aspects = _calculate_aspects(placements)
+    return {"houses": houses, "placements": placements, "aspects": aspects}

--- a/tests/test_house_analysis.py
+++ b/tests/test_house_analysis.py
@@ -1,0 +1,57 @@
+import swisseph as swe
+from backend.house_analysis import analyze_houses
+
+
+def test_house_system_override(monkeypatch):
+    calls = []
+
+    def fake_houses(jd, lat, lon, hsys=b'P'):
+        calls.append(hsys)
+        return ([i * 30.0 for i in range(12)], [0] * 8)
+
+    monkeypatch.setattr(swe, 'houses', fake_houses)
+
+    binfo = {
+        'jd_ut': 0,
+        'latitude': 0,
+        'longitude': 0,
+        'cusps': [0] * 12,
+    }
+    planets = [{'name': 'Sun', 'longitude': 10.0, 'sign': 1}]
+
+    res = analyze_houses(binfo, planets, house_system='W')
+    assert calls[0] == b'W'
+    assert res['placements']['Sun']['house'] == 1
+    assert res['houses'][1] == ['Sun']
+
+
+def test_cusp_boundary():
+    cusps = [i * 30.0 for i in range(12)]
+    binfo = {
+        'jd_ut': 0,
+        'latitude': 0,
+        'longitude': 0,
+        'cusps': cusps,
+    }
+    planet = {'name': 'Sun', 'longitude': 30.0, 'sign': 2}
+    res = analyze_houses(binfo, [planet])
+    assert res['placements']['Sun']['house'] == 2
+
+
+def test_mutual_aspects():
+    cusps = [i * 30.0 for i in range(12)]
+    binfo = {
+        'jd_ut': 0,
+        'latitude': 0,
+        'longitude': 0,
+        'cusps': cusps,
+    }
+    planets = [
+        {'name': 'Mars', 'longitude': 0.0, 'sign': 1},
+        {'name': 'Saturn', 'longitude': 180.0, 'sign': 7},
+    ]
+    res = analyze_houses(binfo, planets)
+    pairs = [set(p) for p in res['aspects']['mutual_aspects']]
+    assert {'Mars', 'Saturn'} in pairs
+    assert res['placements']['Mars']['house'] == 1
+    assert res['placements']['Saturn']['house'] == 7


### PR DESCRIPTION
## Summary
- add ability to compute house data for any house system
- return sign/house placements and mutual aspects
- test house system override, cusp handling and aspect logic

## Testing
- `npm test`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef240dc648320b76a5e17b567d077