### PR TITLE
Fix divisional chart test imports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,11 +27,14 @@ from backend.house_analysis import analyze_houses
 from backend.core_elements import calculate_core_elements
 
 # New Vedic modules
-from backend.divisional_charts import get_vargottama_planets
+from backend.divisional_charts import (
+    get_vargottama_planets,
+    calculate_divisional_charts,
+)
 from backend.aspects import calculate_vedic_aspects, calculate_sign_aspects
 from backend.yogas import calculate_all_yogas
 from backend.shadbala import calculate_shadbala, calculate_bhava_bala
-from backend.analysis import full_analysis, calculate_all_divisional_charts
+from backend.analysis import full_analysis
 
 # FastAPI app init
 app = FastAPI(
@@ -118,7 +121,7 @@ def _compute_vedic_profile(request: ProfileRequest):
     core = calculate_core_elements(planets, include_modalities=True)
     
     # Proper divisional charts
-    dcharts = calculate_all_divisional_charts(planets)
+    dcharts = calculate_divisional_charts(planets)
     
     # Vargottama planets
     vargottama = get_vargottama_planets(

--- a/tests/test_dasha_and_dcharts.py
+++ b/tests/test_dasha_and_dcharts.py
@@ -1,10 +1,7 @@
 import datetime
 from backend.dasha import calculate_vimshottari_dasha
-from backend.analysis import (
-    calculate_all_divisional_charts,
-    DIVISIONAL_CHARTS,
-    DIV_CHART_INTERP,
-)
+from backend.analysis import DIV_CHART_INTERP
+from backend.divisional_charts import calculate_divisional_charts
 from backend.d_charts import calculate_basic_divisional_charts
 
 
@@ -49,9 +46,25 @@ def test_pratyantar_depth():
 
 def test_all_divisional_charts_full():
     planets = [{"name": "Sun", "longitude": 15.0}]
-    charts = calculate_all_divisional_charts(planets)
-    assert len(charts) == 60
-    assert set(charts.keys()) == set(DIVISIONAL_CHARTS.keys())
+    charts = calculate_divisional_charts(planets)
+    expected = {
+        "D1",
+        "D2",
+        "D3",
+        "D4",
+        "D7",
+        "D9",
+        "D10",
+        "D12",
+        "D16",
+        "D20",
+        "D24",
+        "D30",
+        "D40",
+        "D45",
+        "D60",
+    }
+    assert set(charts.keys()) == expected
     for mapping in charts.values():
         val = mapping["Sun"]
         assert 1 <= val <= 12

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ def test_profile(monkeypatch):
     monkeypatch.setattr(main, "get_nakshatra", lambda planets: {"nakshatra": "Ashwini", "pada": 1})
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {1: ["Moon"]})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {"Fire": 100})
-    monkeypatch.setattr(main, "calculate_all_divisional_charts", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/profile", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})
@@ -34,7 +34,7 @@ def test_divisional_charts(monkeypatch):
     monkeypatch.setattr(main, "get_nakshatra", lambda planets: {})
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {})
-    monkeypatch.setattr(main, "calculate_all_divisional_charts", lambda *a, **k: {"D1": {}})
+    monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {"D1": {}})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/divisional-charts", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})
@@ -50,7 +50,7 @@ def test_dasha(monkeypatch):
     monkeypatch.setattr(main, "get_nakshatra", lambda planets: {})
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {})
-    monkeypatch.setattr(main, "calculate_all_divisional_charts", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/dasha", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})


### PR DESCRIPTION
## Summary
- update FastAPI backend to use `calculate_divisional_charts`
- adjust divisional chart tests for new API
- patch API usage in main tests

## Testing
- `npm test`
- `PYTHONPATH=. backend/venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f051b4984832084ad37bba33a752d