### PR TITLE
Add Dockerfile and optional Docker CI test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,18 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      use-docker:
+        description: "Run backend tests inside Docker"
+        required: false
+        default: "false"
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      USE_DOCKER: ${{ github.event.inputs.use-docker || 'false' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -16,9 +24,20 @@ jobs:
       - run: npm install
       - run: npm test
       - uses: actions/setup-python@v4
+        if: env.USE_DOCKER != 'true'
         with:
           python-version: '3.11'
       - run: python -m venv backend/venv
+        if: env.USE_DOCKER != 'true'
       - run: backend/venv/bin/pip install -r backend/requirements.txt
+        if: env.USE_DOCKER != 'true'
       - run: backend/venv/bin/pip install pytest
+        if: env.USE_DOCKER != 'true'
       - run: PYTHONPATH=. backend/venv/bin/pytest -q
+        if: env.USE_DOCKER != 'true'
+      - name: Build backend Docker image
+        if: env.USE_DOCKER == 'true'
+        run: docker build -t backend-tests -f backend/Dockerfile .
+      - name: Run backend tests in Docker
+        if: env.USE_DOCKER == 'true'
+        run: docker run --rm -v ${{ github.workspace }}/tests:/tests backend-tests bash -c "pip install pytest && PYTHONPATH=/app pytest -q /tests"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ PYTHONPATH=. pytest -q
 
 The backend tests stub all external dependencies so no API keys or internet access are required.
 
+To run the backend tests inside the Docker container, build the image and mount the test suite:
+
+```bash
+docker build -f backend/Dockerfile -t backend-tests .
+docker run --rm -v $(pwd)/tests:/tests backend-tests bash -c "pip install pytest && PYTHONPATH=/app pytest -q /tests"
+```
+
 ## Continuous integration
 
 Automated tests run on GitHub Actions for every push and pull request. The workflow installs Node and Python dependencies and executes both the frontend and backend test suites.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/ /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add backend Dockerfile
- describe running backend tests in the container
- allow CI workflow to optionally build Docker image for backend tests

## Testing
- `npm test`
- `PYTHONPATH=. backend/venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f0b5f37088320801f89f9d224ac5d