### PR TITLE
Add component tests

### DIFF
--- a/src/components/BasicInfo.test.jsx
+++ b/src/components/BasicInfo.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import BasicInfo from './BasicInfo';
+
+const sample = {
+  date: '2000-01-01',
+  time: '12:00',
+  location: 'Delhi',
+  latitude: 28.6139,
+  longitude: 77.209,
+  timezone: 'IST',
+};
+
+test('renders birth details heading and location', () => {
+  render(<BasicInfo birth={sample} />);
+  expect(screen.getByText(/birth details/i)).toBeDefined();
+  expect(screen.getByText(/Delhi/i)).toBeDefined();
+});

--- a/src/components/HouseAnalysis.test.jsx
+++ b/src/components/HouseAnalysis.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import HouseAnalysis from './HouseAnalysis';
+
+const sample = {
+  1: 'Self expression',
+  2: ['Finance', 'Values'],
+};
+
+test('renders house analysis heading and first entry', () => {
+  render(<HouseAnalysis houses={sample} />);
+  expect(screen.getByText(/house analysis/i)).toBeDefined();
+  expect(
+    screen.getByText((content, node) => node.textContent === 'House 1: Self expression')
+  ).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add tests for BasicInfo and HouseAnalysis components

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0d7fbdac8320a1cd76766908f08c