### PR TITLE
Add Ashtakavarga calculations

### DIFF
--- a/backend/ashtakavarga.py
+++ b/backend/ashtakavarga.py
@@ -1,0 +1,56 @@
+# backend/ashtakavarga.py
+"""Simplified Ashtakavarga calculations."""
+
+from typing import Dict, List
+
+# Patterns of benefic houses counted from a planet's sign.
+# Each set contains the offsets (1-12) that yield a bindu.
+BINDU_PATTERNS: Dict[str, set] = {
+    "Sun": {1, 2, 4, 7, 8, 9, 10, 11},
+    "Moon": {1, 2, 3, 5, 6, 7, 9, 11},
+    "Mars": {1, 3, 4, 6, 8, 10, 11, 12},
+    "Mercury": {1, 2, 4, 6, 8, 10, 11, 12},
+    "Jupiter": {1, 2, 4, 5, 7, 9, 10, 11},
+    "Venus": {1, 2, 3, 4, 5, 7, 9, 10},
+    "Saturn": {1, 2, 3, 5, 6, 7, 10, 11},
+    "Rahu": {1, 2, 4, 6, 8, 9, 10, 11},
+    "Ketu": {1, 2, 4, 6, 8, 9, 10, 11},
+}
+
+
+def calculate_ashtakavarga(planets: List[dict]) -> Dict[str, Dict[int, int]]:
+    """Return Ashtakavarga points for each planet and house.
+
+    Parameters
+    ----------
+    planets: list of dict
+        Each dict must contain ``name`` and ``sign`` keys where sign is an
+        integer 1..12.
+
+    Returns
+    -------
+    dict
+        Mapping with ``bav`` (Bhinnashtakavarga) for every planet and
+        ``total_points`` containing summed points per house.
+    """
+
+    bav = {}
+    totals = {h: 0 for h in range(1, 13)}
+
+    for planet in planets:
+        name = planet.get("name")
+        sign = planet.get("sign")
+        pattern = BINDU_PATTERNS.get(name)
+        if pattern is None or sign is None:
+            continue
+
+        points = {}
+        for house in range(1, 13):
+            # Offset of the house from planet's sign (1-12)
+            offset = (house - sign) % 12 + 1
+            val = 1 if offset in pattern else 0
+            points[house] = val
+            totals[house] += val
+        bav[name] = points
+
+    return {"bav": bav, "total_points": totals}

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from backend.divisional_charts import (
 from backend.aspects import calculate_vedic_aspects, calculate_sign_aspects
 from backend.yogas import calculate_all_yogas
 from backend.shadbala import calculate_shadbala, calculate_bhava_bala
+from backend.ashtakavarga import calculate_ashtakavarga
 from backend.analysis import full_analysis
 
 # FastAPI app init
@@ -160,11 +161,8 @@ def _compute_vedic_profile(request: ProfileRequest):
     # House strengths (Bhava Bala)
     bhava_bala = calculate_bhava_bala(houses, planets, binfo)
     
-    # Ashtakavarga (simplified - would need full implementation)
-    ashtakavarga = {
-        'note': 'Full Ashtakavarga calculation to be implemented',
-        'total_points': {}  # Would calculate benefic points
-    }
+    # Ashtakavarga
+    ashtakavarga = calculate_ashtakavarga(planets)
     
     # Analysis with all components
     analysis_results = full_analysis(

--- a/tests/test_ashtakavarga.py
+++ b/tests/test_ashtakavarga.py
@@ -1,0 +1,37 @@
+from backend.ashtakavarga import calculate_ashtakavarga
+
+
+def test_example_chart_one():
+    planets = [
+        {"name": "Sun", "sign": 1},
+        {"name": "Moon", "sign": 4},
+        {"name": "Mars", "sign": 6},
+    ]
+    res = calculate_ashtakavarga(planets)
+    expected_bav = {
+        "Sun": {1: 1, 2: 1, 3: 0, 4: 1, 5: 0, 6: 0, 7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 0},
+        "Moon": {1: 0, 2: 1, 3: 0, 4: 1, 5: 1, 6: 1, 7: 0, 8: 1, 9: 1, 10: 1, 11: 0, 12: 1},
+        "Mars": {1: 1, 2: 0, 3: 1, 4: 1, 5: 1, 6: 1, 7: 0, 8: 1, 9: 1, 10: 0, 11: 1, 12: 0},
+    }
+    expected_totals = {1: 2, 2: 2, 3: 1, 4: 3, 5: 2, 6: 2, 7: 1, 8: 3, 9: 3, 10: 2, 11: 2, 12: 1}
+    assert res["bav"] == expected_bav
+    assert res["total_points"] == expected_totals
+
+
+def test_example_chart_two():
+    planets = [
+        {"name": "Mercury", "sign": 2},
+        {"name": "Jupiter", "sign": 5},
+        {"name": "Venus", "sign": 9},
+        {"name": "Saturn", "sign": 11},
+    ]
+    res = calculate_ashtakavarga(planets)
+    expected_bav = {
+        "Mercury": {1: 1, 2: 1, 3: 1, 4: 0, 5: 1, 6: 0, 7: 1, 8: 0, 9: 1, 10: 0, 11: 1, 12: 1},
+        "Jupiter": {1: 1, 2: 1, 3: 1, 4: 0, 5: 1, 6: 1, 7: 0, 8: 1, 9: 1, 10: 0, 11: 1, 12: 0},
+        "Venus": {1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 6: 1, 7: 0, 8: 0, 9: 1, 10: 1, 11: 1, 12: 1},
+        "Saturn": {1: 1, 2: 0, 3: 1, 4: 1, 5: 1, 6: 0, 7: 0, 8: 1, 9: 1, 10: 0, 11: 1, 12: 1},
+    }
+    expected_totals = {1: 4, 2: 2, 3: 4, 4: 1, 5: 4, 6: 2, 7: 1, 8: 2, 9: 4, 10: 1, 11: 4, 12: 3}
+    assert res["bav"] == expected_bav
+    assert res["total_points"] == expected_totals

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ def test_profile(monkeypatch):
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {1: ["Moon"]})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {"Fire": 100})
     monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_ashtakavarga", lambda *a, **k: {"bav": {}, "total_points": {}})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/profile", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})
@@ -35,6 +36,7 @@ def test_divisional_charts(monkeypatch):
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {"D1": {}})
+    monkeypatch.setattr(main, "calculate_ashtakavarga", lambda *a, **k: {"bav": {}, "total_points": {}})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/divisional-charts", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})
@@ -52,6 +54,7 @@ def test_dasha(monkeypatch):
     monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {})
     monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_ashtakavarga", lambda *a, **k: {"bav": {}, "total_points": {}})
     monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
 
     resp = client.post("/dasha", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})


### PR DESCRIPTION
## Summary
- implement simplified Ashtakavarga calculations
- integrate calculation into Vedic profile pipeline
- stub out Ashtakavarga in API tests
- add dedicated tests for the new module

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f10d9e28c8320be15301895312755