### PR TITLE
Add environment overrides for config

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,11 @@
 from pathlib import Path
+import os
 import yaml
 
 DEFAULTS = {
-    "ayanamsa": "fagan_bradley",
+    "ayanamsa": "lahiri",
     "node_type": "mean",
-    "house_system": "placidus",
+    "house_system": "whole_sign",
 }
 
 _cfg = None
@@ -14,6 +15,7 @@ def load_config():
     if _cfg is not None:
         return _cfg
     cfg = DEFAULTS.copy()
+
     path = Path(__file__).with_name("config.yaml")
     if path.exists():
         try:
@@ -23,5 +25,11 @@ def load_config():
                     cfg[k] = str(data[k]).lower()
         except Exception:
             pass
+
+    for k in DEFAULTS:
+        val = os.getenv(k.upper())
+        if val is not None:
+            cfg[k] = str(val).lower()
+
     _cfg = cfg
     return cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+import os
+from backend import config
+from pathlib import Path
+
+
+def setup_function(function):
+    # reset cache before each test
+    config._cfg = None
+
+
+def test_load_config_defaults(monkeypatch):
+    monkeypatch.setattr(config.Path, "exists", lambda self: False)
+    monkeypatch.delenv("AYANAMSA", raising=False)
+    monkeypatch.delenv("NODE_TYPE", raising=False)
+    monkeypatch.delenv("HOUSE_SYSTEM", raising=False)
+    cfg = config.load_config()
+    assert cfg == config.DEFAULTS
+
+
+def test_load_config_env_override(monkeypatch):
+    monkeypatch.setattr(config.Path, "exists", lambda self: False)
+    monkeypatch.setenv("AYANAMSA", "raman")
+    cfg = config.load_config()
+    assert cfg["ayanamsa"] == "raman"
+    assert cfg["node_type"] == config.DEFAULTS["node_type"]
+
+
+def test_load_config_yaml_override(monkeypatch, tmp_path):
+    data = "ayanamsa: raman\nhouse_system: equal\n"
+
+    class DummyPath(Path):
+        _flavour = type(Path())._flavour
+        def __new__(cls, *args, **kwargs):
+            return super().__new__(cls, *args, **kwargs)
+        def with_name(self, name):
+            return tmp_path / name
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(data)
+
+    monkeypatch.setattr(config, "Path", DummyPath)
+    monkeypatch.delenv("AYANAMSA", raising=False)
+    cfg = config.load_config()
+    assert cfg["ayanamsa"] == "raman"
+    assert cfg["house_system"] == "equal"


### PR DESCRIPTION
## Summary
- update configuration defaults
- allow environment variable overrides in `load_config`
- test `load_config` with defaults, YAML, and env variables

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f147bfe4483209a1ee8aa2360483d