### PR TITLE
Add tests for planets and yoga calculations

### DIFF
--- a/tests/test_planets.py
+++ b/tests/test_planets.py
@@ -1,0 +1,37 @@
+import swisseph as swe
+from backend import planets as planets_mod
+
+
+def test_calculate_planets_with_mock(monkeypatch):
+    binfo = {'jd_ut': 0, 'sidereal_offset': 24}
+    values = {
+        swe.SUN: 10.0,
+        swe.MOON: 20.0,
+        swe.MERCURY: 30.0,
+        swe.VENUS: 40.0,
+        swe.MARS: 50.0,
+        swe.JUPITER: 60.0,
+        swe.SATURN: 70.0,
+        swe.MEAN_NODE: 80.0,
+    }
+
+    def fake_calc_ut(jd, pid):
+        return [values.get(pid, 0.0), 0.0, 0.0], None
+
+    monkeypatch.setattr(swe, "calc_ut", fake_calc_ut)
+    monkeypatch.setattr(planets_mod, "_is_retrograde", lambda *a, **k: False)
+
+    res = planets_mod.calculate_planets(binfo)
+    assert len(res) == 9
+
+    sun = res[0]
+    assert sun["name"] == "Sun"
+    assert sun["longitude"] == (10.0 - 24) % 360
+    assert sun["sign"] == 12
+    assert sun["degree"] == 16.0
+
+    ketu = res[-1]
+    assert ketu["name"] == "Ketu"
+    rahu_lon = (80.0 - 24) % 360
+    assert ketu["longitude"] == (rahu_lon + 180) % 360
+    assert ketu["retrograde"] is True

--- a/tests/test_yogas_shadbala.py
+++ b/tests/test_yogas_shadbala.py
@@ -1,0 +1,46 @@
+from datetime import time
+from backend.yogas import calculate_all_yogas
+from backend.shadbala import calculate_shadbala
+from backend.divisional_charts import calculate_all_vargas
+
+
+def test_calculate_all_yogas_empty():
+    res = calculate_all_yogas([], {"houses": {}})
+    assert res["total_count"] == 0
+    assert res["summary"] == []
+    for yogas in res["yogas"].values():
+        assert yogas == []
+
+
+def test_calculate_all_yogas_nabhasa_only():
+    planets = [
+        {"name": n, "sign": 1} for n in ["Sun", "Moon", "Mars", "Mercury", "Jupiter", "Venus", "Saturn"]
+    ]
+    res = calculate_all_yogas(planets, {"houses": {}})
+    names = [y["name"] for y in res["yogas"]["nabhasa_yogas"]]
+    assert "Rajju Yoga" in names
+    assert res["yogas"]["chandra_yogas"]
+    assert res["total_count"] == 1 + len(res["yogas"]["chandra_yogas"])
+
+
+def test_calculate_shadbala_edge_cases():
+    planets = [
+        {"name": "Sun", "sign": 5, "degree": 10, "retrograde": False},
+        {"name": "Saturn", "sign": 1, "degree": 20, "retrograde": False},
+        {"name": "Rahu", "sign": 10, "degree": 0, "retrograde": True},
+    ]
+    binfo = {"birth_time": time(12, 0), "jd_ut": 2451545.0}
+    houses = {"houses": {1: ["Sun"], 7: ["Saturn"]}}
+    res = calculate_shadbala(planets, binfo, houses)
+    assert "Rahu" not in res
+    assert res["Saturn"]["sthana_bala"] == 0
+    assert res["Sun"]["dig_bala"] == 30
+
+
+def test_calculate_all_vargas_values():
+    res = calculate_all_vargas(15.0)
+    assert len(res) == 60
+    assert res["D1"] == 1
+    assert res["D9"] == 5
+    assert res["D10"] == 6
+    assert res["D60"] == 7


### PR DESCRIPTION
## Summary
- add tests for calculate_planets using mocked SwissEph data
- test yoga and shadbala edge cases
- ensure all divisional charts are checked

## Testing
- `npm test`
- `PYTHONPATH=. backend/venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1487b9a4832099687159ffdc796e