### PR TITLE
Implement caching for astrology profile

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -6,6 +6,7 @@ DEFAULTS = {
     "ayanamsa": "lahiri",
     "node_type": "mean",
     "house_system": "whole_sign",
+    "cache_enabled": "true",
 }
 
 _cfg = None

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -2,3 +2,4 @@
 ayanamsa: lahiri  # Changed from fagan_bradley to lahiri (standard for Vedic)
 node_type: mean   # This is correct for Vedic
 house_system: whole_sign  # Changed from placidus to whole_sign (traditional Vedic)
+cache_enabled: true

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,35 @@
+from datetime import date, time
+from backend import main
+
+
+def test_profile_cache(monkeypatch):
+    calls = {"geo": 0}
+    def fake_geo(loc):
+        calls["geo"] += 1
+        return 10.0, 20.0, "UTC"
+
+    monkeypatch.setattr(main, "geocode_location", fake_geo)
+    monkeypatch.setattr(main, "get_birth_info", lambda **k: {"jd_ut": 0, "sidereal_offset": 0, "cusps": []})
+    monkeypatch.setattr(main, "calculate_planets", lambda *a, **k: [])
+    monkeypatch.setattr(main, "calculate_vimshottari_dasha", lambda *a, **k: [])
+    monkeypatch.setattr(main, "get_nakshatra", lambda *a, **k: {})
+    monkeypatch.setattr(main, "analyze_houses", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_core_elements", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_divisional_charts", lambda *a, **k: {})
+    monkeypatch.setattr(main, "get_vargottama_planets", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_vedic_aspects", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_sign_aspects", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_all_yogas", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_shadbala", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_bhava_bala", lambda *a, **k: {})
+    monkeypatch.setattr(main, "calculate_ashtakavarga", lambda *a, **k: {})
+    monkeypatch.setattr(main, "full_analysis", lambda *a, **k: {})
+
+    main.CONFIG["cache_enabled"] = "true"
+    main.clear_profile_cache()
+
+    req = main.ProfileRequest(date=date(2020,1,1), time=time(12,0), location="Delhi")
+    main._compute_vedic_profile(req)
+    assert calls["geo"] == 1
+    main._compute_vedic_profile(req)
+    assert calls["geo"] == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ def test_load_config_defaults(monkeypatch):
     monkeypatch.delenv("AYANAMSA", raising=False)
     monkeypatch.delenv("NODE_TYPE", raising=False)
     monkeypatch.delenv("HOUSE_SYSTEM", raising=False)
+    monkeypatch.delenv("CACHE_ENABLED", raising=False)
     cfg = config.load_config()
     assert cfg == config.DEFAULTS
 
@@ -20,13 +21,15 @@ def test_load_config_defaults(monkeypatch):
 def test_load_config_env_override(monkeypatch):
     monkeypatch.setattr(config.Path, "exists", lambda self: False)
     monkeypatch.setenv("AYANAMSA", "raman")
+    monkeypatch.setenv("CACHE_ENABLED", "false")
     cfg = config.load_config()
     assert cfg["ayanamsa"] == "raman"
     assert cfg["node_type"] == config.DEFAULTS["node_type"]
+    assert cfg["cache_enabled"] == "false"
 
 
 def test_load_config_yaml_override(monkeypatch, tmp_path):
-    data = "ayanamsa: raman\nhouse_system: equal\n"
+    data = "ayanamsa: raman\nhouse_system: equal\ncache_enabled: false\n"
 
     class DummyPath(Path):
         _flavour = type(Path())._flavour
@@ -42,3 +45,4 @@ def test_load_config_yaml_override(monkeypatch, tmp_path):
     cfg = config.load_config()
     assert cfg["ayanamsa"] == "raman"
     assert cfg["house_system"] == "equal"
+    assert cfg["cache_enabled"] == "false"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ client = TestClient(main.app)
 
 
 def test_profile(monkeypatch):
+    main.clear_profile_cache()
     # stub external services
     monkeypatch.setattr(main, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
 
@@ -28,6 +29,7 @@ def test_profile(monkeypatch):
 
 
 def test_divisional_charts(monkeypatch):
+    main.clear_profile_cache()
     monkeypatch.setattr(main, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
     monkeypatch.setattr(main, "get_birth_info", lambda **k: {"jd_ut": 0, "cusps": [0]*12})
     monkeypatch.setattr(main, "calculate_planets", lambda *a, **k: [])
@@ -46,6 +48,7 @@ def test_divisional_charts(monkeypatch):
 
 
 def test_dasha(monkeypatch):
+    main.clear_profile_cache()
     monkeypatch.setattr(main, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
     monkeypatch.setattr(main, "get_birth_info", lambda **k: {"jd_ut": 0, "cusps": [0]*12})
     monkeypatch.setattr(main, "calculate_planets", lambda *a, **k: [])
@@ -64,6 +67,7 @@ def test_dasha(monkeypatch):
 
 
 def test_geocode_error(monkeypatch):
+    main.clear_profile_cache()
     def fail(loc):
         raise ValueError("bad location")
 
@@ -78,6 +82,7 @@ def test_geocode_error(monkeypatch):
 
 
 def test_birth_info_invalid(monkeypatch):
+    main.clear_profile_cache()
     monkeypatch.setattr(main, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
 
     def bad_birth(**kwargs):
@@ -94,6 +99,7 @@ def test_birth_info_invalid(monkeypatch):
 
 
 def test_swisseph_failure(monkeypatch):
+    main.clear_profile_cache()
     monkeypatch.setattr(main, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
     monkeypatch.setattr(main, "get_birth_info", lambda **k: {"jd_ut": 0, "cusps": [0]*12, "sidereal_offset": 0})
 

--- a/tests/test_planets.py
+++ b/tests/test_planets.py
@@ -3,6 +3,7 @@ from backend import planets as planets_mod
 
 
 def test_calculate_planets_with_mock(monkeypatch):
+    planets_mod.clear_planet_cache()
     binfo = {'jd_ut': 0, 'sidereal_offset': 24}
     values = {
         swe.SUN: 10.0,


### PR DESCRIPTION
## Summary
- add `cache_enabled` config default and YAML
- implement in-memory profile cache and lru cached planet calculations
- expose cache clear helpers for tests
- update tests with cache clearing and new config expectations
- add regression test ensuring caching is used

## Testing
- `npm test`
- `backend/venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f16a840b4832084f0fe9b9fab988f