### PR TITLE
Add locale and async geocoding support

### DIFF
--- a/backend/geocoder.py
+++ b/backend/geocoder.py
@@ -1,10 +1,12 @@
 import os
 import time
 import logging
+import asyncio
 from functools import lru_cache
 
 from geopy.geocoders import Nominatim
 from timezonefinder import TimezoneFinder
+import httpx
 
 try:
     import googlemaps
@@ -18,13 +20,16 @@ _geopy = Nominatim(user_agent="vedic-astrology-geocoder")
 _tzfinder = TimezoneFinder()
 
 
-def _geocode_once(query: str):
+def _geocode_once(query: str, locale: str | None = None):
     """Return (lat, lon, tz) for a single geocode query."""
     lat = lon = tz = None
 
     if gmaps:
         try:
-            results = gmaps.geocode(query)
+            if locale:
+                results = gmaps.geocode(query, language=locale)
+            else:
+                results = gmaps.geocode(query)
             if results:
                 loc = results[0]["geometry"]["location"]
                 lat, lon = loc.get("lat"), loc.get("lng")
@@ -36,7 +41,10 @@ def _geocode_once(query: str):
 
     if lat is None or lon is None:
         try:
-            geo = _geopy.geocode(query, exactly_one=True)
+            if locale:
+                geo = _geopy.geocode(query, exactly_one=True, language=locale)
+            else:
+                geo = _geopy.geocode(query, exactly_one=True)
             if geo:
                 lat, lon = geo.latitude, geo.longitude
         except Exception as ex:  # pragma: no cover - network
@@ -45,8 +53,48 @@ def _geocode_once(query: str):
     return lat, lon, tz
 
 
+async def _async_geocode_once(query: str, locale: str | None = None):
+    """Async geocode using httpx when Google Maps is unavailable."""
+    lat = lon = tz = None
+
+    if gmaps:
+        def sync_call():
+            try:
+                if locale:
+                    results = gmaps.geocode(query, language=locale)
+                else:
+                    results = gmaps.geocode(query)
+                if results:
+                    loc = results[0]["geometry"]["location"]
+                    lt, ln = loc.get("lat"), loc.get("lng")
+                    tz_info = gmaps.timezone({"location": (lt, ln),
+                                              "timestamp": int(time.time())})
+                    return lt, ln, tz_info.get("timeZoneId")
+            except Exception as ex:  # pragma: no cover - network
+                logger.warning("Google geocode failed: %s", ex)
+            return None, None, None
+
+        lat, lon, tz = await asyncio.get_event_loop().run_in_executor(None, sync_call)
+    else:
+        params = {"q": query, "format": "json", "limit": 1}
+        if locale:
+            params["accept-language"] = locale
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get("https://nominatim.openstreetmap.org/search", params=params)
+                resp.raise_for_status()
+                data = resp.json()
+                if data:
+                    lat = float(data[0]["lat"])
+                    lon = float(data[0]["lon"])
+        except Exception as ex:  # pragma: no cover - network
+            logger.warning("Async geocode failed: %s", ex)
+
+    return lat, lon, tz
+
+
 @lru_cache(maxsize=128)
-def geocode_location(query: str):
+def geocode_location(query: str, locale: str | None = None):
     """Return (lat, lon, timezone) for a place string."""
     tokens = [t.strip() for t in query.split(',')]
     candidates = [', '.join(tokens[:i]) for i in range(len(tokens), 0, -1)]
@@ -55,7 +103,28 @@ def geocode_location(query: str):
 
     lat = lon = tz = None
     for cand in candidates:
-        lat, lon, tz = _geocode_once(cand)
+        lat, lon, tz = _geocode_once(cand, locale=locale)
+        if lat is not None and lon is not None:
+            break
+
+    if lat is None or lon is None:
+        raise ValueError(f"Could not resolve location '{query}'")
+
+    if not tz:
+        tz = _tzfinder.timezone_at(lat=lat, lng=lon) or 'UTC'
+    return lat, lon, tz
+
+
+async def geocode_location_async(query: str, locale: str | None = None):
+    """Async version of geocode_location using httpx when gmaps is unavailable."""
+    tokens = [t.strip() for t in query.split(',')]
+    candidates = [', '.join(tokens[:i]) for i in range(len(tokens), 0, -1)]
+    if len(tokens) > 1:
+        candidates.extend(', '.join(tokens[i:]) for i in range(1, len(tokens)))
+
+    lat = lon = tz = None
+    for cand in candidates:
+        lat, lon, tz = await _async_geocode_once(cand, locale=locale)
         if lat is not None and lon is not None:
             break
 

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -65,7 +65,7 @@ def test_geocode_cached(monkeypatch):
     monkeypatch.setattr(geocoder, "gmaps", None)
     call_count = {"n": 0}
 
-    def fake_once(q):
+    def fake_once(q, locale=None):
         call_count["n"] += 1
         return 1.0, 2.0, "Asia/Kolkata"
 
@@ -75,3 +75,51 @@ def test_geocode_cached(monkeypatch):
         assert (lat, lon, tz) == (1.0, 2.0, "Asia/Kolkata")
 
     assert call_count["n"] == 1
+
+
+def test_geocode_locale(monkeypatch):
+    geocoder.geocode_location.cache_clear()
+    monkeypatch.setattr(geocoder, "gmaps", None)
+    captured = {}
+
+    def fake_geocode(q, exactly_one=True, language=None):
+        captured["lang"] = language
+        return SimpleNamespace(latitude=1.0, longitude=2.0)
+
+    monkeypatch.setattr(geocoder._geopy, "geocode", fake_geocode)
+    monkeypatch.setattr(geocoder, "_tzfinder", SimpleNamespace(timezone_at=lambda lat, lng: "Asia/Kolkata"))
+
+    lat, lon, tz = geocoder.geocode_location("Renukoot, Sonbhadra, India", locale="hi")
+    assert lat == 1.0
+    assert lon == 2.0
+    assert tz == "Asia/Kolkata"
+    assert captured["lang"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_geocode_async(monkeypatch):
+    geocoder.geocode_location.cache_clear()
+    monkeypatch.setattr(geocoder, "gmaps", None)
+
+    async def fake_get(url, params=None):
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: [{"lat": "1.0", "lon": "2.0"}]
+        )
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def get(self, url, params=None):
+            assert params.get("accept-language") == "en"
+            return await fake_get(url, params)
+
+    monkeypatch.setattr(geocoder.httpx, "AsyncClient", DummyClient)
+    monkeypatch.setattr(geocoder, "_tzfinder", SimpleNamespace(timezone_at=lambda lat, lng: "UTC"))
+
+    lat, lon, tz = await geocoder.geocode_location_async("Renukoot", locale="en")
+    assert lat == 1.0
+    assert lon == 2.0
+    assert tz == "UTC"


### PR DESCRIPTION
## Summary
- support optional locale in `geocode_location`
- implement async geocoding with httpx when Google Maps is unavailable
- cover locale and async paths in geocoder tests

## Testing
- `npm test`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f16b88a348320bb6ee58e3ce6a9ac