### PR TITLE
Switch deploy to Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,13 @@ jobs:
       - run: backend/venv/bin/pip install pytest pytest-asyncio
       - run: PYTHONPATH=. backend/venv/bin/pytest -q
       - run: npm run build
-      - name: Upload frontend via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+      - name: Deploy frontend to Netlify
+        uses: netlify/actions/cli@v2
         with:
-          server: ${{ secrets.HOSTINGER_FTP_HOST }}
-          username: ${{ secrets.HOSTINGER_FTP_USER }}
-          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
-          local-dir: dist
-          server-dir: public_html/
+          args: deploy --dir=dist --prod
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       - name: Deploy backend over SSH
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ The interface is composed of several reusable React components:
 - **HouseAnalysis** – explains how each astrological house influences life areas.
 - **DashaTable** – lists major planetary periods with start and end dates.
 - **DashaChart** – visual timeline of those periods; hover to read descriptions.
+
+## Deployment
+
+The frontend is deployed to Netlify while the FastAPI backend stays on Hostinger.
+
+1. Set the `VITE_API_BASE_URL` variable in Netlify to the full URL of your backend (e.g. `https://api.cosmicdharma.app`).
+2. Connect this repository to Netlify so pushes to `main` trigger a build. Netlify uses `npm run build` and publishes the `dist` directory as defined in `netlify.toml`.
+3. Point your `cosmicdharma.app` domain to Netlify and add it as a custom domain in the Netlify dashboard.
+4. GitHub Actions deploy the backend over SSH and trigger a Netlify deploy using the `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[context.production.environment]
+  # Set the backend API URL in Netlify settings or override here
+  VITE_API_BASE_URL = ""

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ function App() {
   const [profile, setProfile] = useState(null);
 
   const { name, birthDate, birthTime, location } = form;
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -60,7 +61,7 @@ function App() {
     setError('');
 
     try {
-      const res = await fetch('/profile', {
+      const res = await fetch(`${API_BASE}/profile`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ date: birthDate, time: birthTime, location }),


### PR DESCRIPTION
## Summary
- update `App.jsx` to read `VITE_API_BASE_URL`
- create a `netlify.toml` config
- deploy frontend with Netlify in GitHub Actions
- document deployment instructions

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f39a2c1188320a1b023b7bd9aa754