### PR TITLE
Use running loop for async geocoder

### DIFF
--- a/backend/geocoder.py
+++ b/backend/geocoder.py
@@ -74,7 +74,7 @@ async def _async_geocode_once(query: str, locale: str | None = None):
                 logger.warning("Google geocode failed: %s", ex)
             return None, None, None
 
-        lat, lon, tz = await asyncio.get_event_loop().run_in_executor(None, sync_call)
+        lat, lon, tz = await asyncio.get_running_loop().run_in_executor(None, sync_call)
     else:
         params = {"q": query, "format": "json", "limit": 1}
         if locale:


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop()` instead of deprecated `get_event_loop()`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ce4ec0eac832092b6365dcfd8346c