### PR TITLE
Add API helper to prefix base URL

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import apiFetch from '../util/api';
 
 export default function AdminPage() {
   const [posts, setPosts] = useState([]);
@@ -13,7 +14,7 @@ export default function AdminPage() {
   };
 
   const load = () => {
-    fetch('/admin/posts', { headers })
+    apiFetch('admin/posts', { headers })
       .then(res => res.json())
       .then(setPosts)
       .catch(() => setPosts([]));
@@ -32,7 +33,7 @@ export default function AdminPage() {
   const handleContentChange = val => setForm({ ...form, content: val });
 
   const handleSave = async () => {
-    const res = await fetch(`/admin/posts/${editingId}`, {
+    const res = await apiFetch(`admin/posts/${editingId}`, {
       method: 'PUT',
       headers,
       body: JSON.stringify(form)
@@ -47,7 +48,7 @@ export default function AdminPage() {
 
   const handleDelete = async id => {
     if (!window.confirm('Delete this post?')) return;
-    const res = await fetch(`/admin/posts/${id}`, {
+    const res = await apiFetch(`admin/posts/${id}`, {
       method: 'DELETE',
       headers
     });

--- a/pages/editor.js
+++ b/pages/editor.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { useRouter } from 'next/router';
+import apiFetch from '../util/api';
 
 export default function PostEditorPage() {
   const router = useRouter();
@@ -12,7 +13,7 @@ export default function PostEditorPage() {
   const handleSubmit = async e => {
     e.preventDefault();
     const token = localStorage.getItem('token');
-    const res = await fetch('/posts', {
+    const res = await apiFetch('posts', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import apiFetch from '../util/api';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -8,7 +9,7 @@ export default function LoginPage() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    const res = await fetch('/login', {
+    const res = await apiFetch('login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams(form)

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import apiFetch from '../../util/api';
 
 export default function PostViewPage() {
   const router = useRouter();
@@ -8,7 +9,7 @@ export default function PostViewPage() {
 
   useEffect(() => {
     if (!id) return;
-    fetch(`/posts/${id}`)
+    apiFetch(`posts/${id}`)
       .then(res => res.json())
       .then(data => setPost(data))
       .catch(() => setPost(null));

--- a/pages/posts/index.js
+++ b/pages/posts/index.js
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import apiFetch from '../../util/api';
 
 export default function PostListPage() {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    fetch('/posts')
+    apiFetch('posts')
       .then(res => res.json())
       .then(data => setPosts(data))
       .catch(() => setPosts([]));

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import apiFetch from '../util/api';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -8,7 +9,7 @@ export default function RegisterPage() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    const res = await fetch('/register', {
+    const res = await apiFetch('register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form)

--- a/util/api.js
+++ b/util/api.js
@@ -1,0 +1,6 @@
+export default function apiFetch(path, options = {}) {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const prefix = base ? base.replace(/\/$/, '') : '';
+  const urlPath = path.startsWith('/') ? path : `/${path}`;
+  return fetch(prefix + urlPath, options);
+}


### PR DESCRIPTION
## Summary
- centralize API URL handling with `apiFetch`
- migrate page fetch calls to use the helper

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cedf10cc88320be49d7cf4fa51dd1