### PR TITLE
Add env example and update backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ cd ..
 
 ### Backend configuration
 
-The backend reads several environment variables for its settings:
+Copy `backend/.env.example` to `backend/.env` and fill in the values. The backend
+reads these environment variables:
 
-* `DATABASE_URL` – connection string for the database. By default it uses
-  `sqlite:///./app.db`, creating `app.db` inside `backend/`.
+* `DATABASE_URL` – connection string for the database. Defaults to
+  `sqlite:///./app.db`.
 * `SECRET_KEY` – secret used to sign authentication tokens.
 * `ACCESS_TOKEN_EXPIRE_MINUTES` – token lifetime in minutes (defaults to `30`).
+* `GOOGLE_MAPS_API_KEY` – optional key for Google Maps geocoding.
+* `AYANAMSA` – ayanamsa used in calculations (`lahiri` by default).
+* `NODE_TYPE` – lunar node calculation (`mean` or `true`).
+* `HOUSE_SYSTEM` – astrological house system (`whole_sign` by default).
+* `CACHE_ENABLED` – enable or disable caching.
 
 To seed the database with demo accounts and posts run:
 
@@ -104,6 +110,8 @@ The frontend is deployed to Netlify while the FastAPI backend stays on Hostinger
 3. Connect this repository to Netlify so pushes to `main` trigger a build. Netlify installs dependencies, runs `npm run build` and uploads the `.next` directory.
 4. Point your `cosmicdharma.app` domain to Netlify and add it as a custom domain in the Netlify dashboard.
 5. GitHub Actions deploy the backend over SSH and trigger a Netlify deploy using the `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets.
+6. On the server, copy `backend/.env.example` to `backend/.env` and provide the
+   production values before starting the FastAPI service.
 
 ## Contributing
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env and adjust values for local development or deployment
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///./app.db
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+GOOGLE_MAPS_API_KEY=
+AYANAMSA=lahiri
+NODE_TYPE=mean
+HOUSE_SYSTEM=whole_sign
+CACHE_ENABLED=true


### PR DESCRIPTION
## Summary
- add `.env.example` with all backend environment variables
- document environment file usage in README
- note `.env` setup in deployment section

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cef663d208320b1575ffe73453d91