### PR TITLE
Add backend test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ The frontend runs on port 3000 and uses environment variables to reach the backe
 
 ## Tests
 
-Run the frontend and backend tests separately or together using NPM scripts:
+Install the extra Python packages used during testing and run the frontend and backend tests separately or together using NPM scripts:
+
+```bash
+pip install -r backend/requirements-dev.txt
+```
 
 ```bash
 # frontend only

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,17 @@
+fastapi
+uvicorn[standard]
+pydantic
+swisseph
+pyswisseph
+timezonefinder
+pytz
+geopy
+geopy[speedups]
+httpx<0.25
+pytest
+pytest-asyncio>=0.21
+pyyaml
+sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+python-multipart


### PR DESCRIPTION
## Summary
- list test-only dependencies under `backend/requirements-dev.txt`
- explain installing dev requirements before running tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf1f557988320bf16b76a36bcc639