### PR TITLE
Improve API fetch and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This project contains a React frontend and a FastAPI backend. When the AI updates this repository, follow these instructions.
 
 ## Setup
-1. Install Node dependencies with `npm install`.
+1. Install Node dependencies with `npm install --legacy-peer-deps` (requires Node 18+).
 2. Create a Python virtual environment under `backend/venv`, activate it, and install requirements:
    ```bash
    cd backend
@@ -17,7 +17,7 @@ This project contains a React frontend and a FastAPI backend. When the AI update
 Use `npm run dev` to launch both the frontend and backend in development mode.
 
 ## Tests
-Run all tests before committing:
+Activate the virtual environment and run all tests before committing:
 ```bash
 npm test
 PYTHONPATH=. pytest -q

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project contains a Next.js frontend and a FastAPI backend used to generate 
 
 ### Install Node dependencies
 
-The project targets **Node.js 18** or later. Install packages with:
+Ensure you have **Node.js 18** or later installed. Install packages with:
 
 ```bash
 npm install --legacy-peer-deps
@@ -21,6 +21,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cd ..
 ```
+Activate this environment whenever you run tests or start the backend.
 
 ### Backend configuration
 
@@ -66,6 +67,7 @@ Install the extra Python packages used during testing and run the frontend and b
 
 ```bash
 pip install -r backend/requirements-dev.txt
+source backend/venv/bin/activate
 ```
 
 ```bash

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { fetchJson } from '../util/api';
 import ProfileForm from '../components/ProfileForm';
 import BasicInfo from '../components/BasicInfo';
 import ProfileSummary from '../components/ProfileSummary';
@@ -7,8 +8,6 @@ import PlanetTable from '../components/PlanetTable';
 import HouseAnalysis from '../components/HouseAnalysis';
 import DashaTable from '../components/DashaTable';
 import DashaChart from '../components/DashaChart';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
 export default function HomePage() {
   const [form, setForm] = useState({ name: '', birthDate: '', birthTime: '', location: '' });
@@ -24,18 +23,16 @@ export default function HomePage() {
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`${API_BASE}/profile/job`, {
+      const data = await fetchJson('/profile/job', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ date: form.birthDate, time: form.birthTime, location: form.location })
+        body: JSON.stringify({
+          date: form.birthDate,
+          time: form.birthTime,
+          location: form.location,
+        }),
       });
-      const data = await res.json();
-      if (res.ok && data.job_id) {
-        setJobId(data.job_id);
-      } else {
-        setError(data.detail || 'Server error');
-        setLoading(false);
-      }
+      setJobId(data.job_id);
     } catch (err) {
       setError(err.message);
       setLoading(false);
@@ -46,8 +43,7 @@ export default function HomePage() {
     if (!jobId) return;
     const id = setInterval(async () => {
       try {
-        const res = await fetch(`${API_BASE}/jobs/${jobId}`);
-        const data = await res.json();
+        const data = await fetchJson(`/jobs/${jobId}`);
         if (data.status === 'complete') {
           setProfile({ ...data.result, request: form });
           setJobId(null);

--- a/util/api.js
+++ b/util/api.js
@@ -4,3 +4,24 @@ export default function apiFetch(path, options = {}) {
   const urlPath = path.startsWith('/') ? path : `/${path}`;
   return fetch(prefix + urlPath, options);
 }
+
+/**
+ * Fetch JSON data from the API and throw an error if the response is not OK.
+ *
+ * @param {string} path - API endpoint path
+ * @param {RequestInit} [options] - fetch options
+ * @returns {Promise<any>} - parsed JSON body
+ */
+export async function fetchJson(path, options = {}) {
+  const res = await apiFetch(path, options);
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error('Invalid JSON response');
+  }
+  if (!res.ok) {
+    throw new Error(data.detail || res.statusText);
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- add `fetchJson` helper for fetching JSON responses and handling errors
- use `fetchJson` in the home page
- document environment setup in README
- clarify contribution workflow in AGENTS

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_685cf4a03c048320ac1dbf445c9036f9