### PR TITLE
Fix bcrypt version warning

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -12,6 +12,7 @@ pytest
 pytest-asyncio>=0.21
 pyyaml
 sqlalchemy
-passlib[bcrypt]
+passlib[bcrypt]>=1.7.4
+bcrypt<4.0
 python-jose[cryptography]
 python-multipart

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ geopy[speedups]
 httpx<0.25
 pytest-asyncio>=0.21
 sqlalchemy
-passlib[bcrypt]
+passlib[bcrypt]>=1.7.4
+bcrypt<4.0
 python-jose[cryptography]
 python-multipart


### PR DESCRIPTION
## Summary
- pin bcrypt to <4.0 and passlib>=1.7.4
- update development requirements as well
- reinstall packages and run seed script

## Testing
- `npm test --silent`
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. backend/venv/bin/python backend/seed_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_685d7c1e0c9483208d2754f4ca7f51af