### PR TITLE
Add table component tests

### DIFF
--- a/components/DashaTable.test.jsx
+++ b/components/DashaTable.test.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import DashaTable from './DashaTable';
+
+const sample = [
+  { lord: 'Sun', start: '2020-01-01', end: '2021-01-01' },
+  { lord: 'Moon', start: '2021-01-01', end: '2022-01-01' },
+];
+
+test('renders mahadasha heading and first row', () => {
+  render(<DashaTable dasha={sample} />);
+  expect(screen.getByText(/vimshottari mahādasha/i)).toBeDefined();
+  expect(screen.getByText(/Sun/i)).toBeDefined();
+});

--- a/components/PlanetTable.test.jsx
+++ b/components/PlanetTable.test.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import PlanetTable from './PlanetTable';
+
+const sample = [
+  { name: 'Sun', sign: 'Aries', degree: 10.5 },
+  { name: 'Moon', sign: 'Taurus', degree: 5.75 },
+];
+
+test('renders planetary positions heading and first planet', () => {
+  render(<PlanetTable planets={sample} />);
+  expect(screen.getByText(/planetary positions/i)).toBeDefined();
+  expect(screen.getByText(/Sun/i)).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add PlanetTable tests
- add DashaTable tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d7c21c7f0832083c2ad65400cc925