### PR TITLE
Add donor user support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -69,6 +69,7 @@ class UserCreate(BaseModel):
     username: str
     email: str
     password: str
+    is_donor: bool = False
 
 
 class Token(BaseModel):
@@ -80,6 +81,7 @@ class UserOut(BaseModel):
     username: str
     email: str
     is_admin: bool
+    is_donor: bool
 
 
 class BlogPostCreate(BaseModel):
@@ -190,6 +192,7 @@ def register(user: UserCreate, db: Session = Depends(get_session)):
         username=user.username,
         email=user.email,
         hashed_password=get_password_hash(user.password),
+        is_donor=user.is_donor,
     )
     db.add(db_user)
     db.commit()
@@ -221,6 +224,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
         username=current_user.username,
         email=current_user.email,
         is_admin=current_user.is_admin,
+        is_donor=current_user.is_donor,
     )
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -12,6 +12,7 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     is_admin = Column(Boolean, default=False, nullable=False)
+    is_donor = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/seed_demo.py
+++ b/backend/seed_demo.py
@@ -27,6 +27,16 @@ def seed():
         )
         db.add(user)
 
+    donor = db.query(User).filter_by(username="donor").first()
+    if not donor:
+        donor = User(
+            username="donor",
+            email="donor@example.com",
+            hashed_password=get_password_hash("donor"),
+            is_donor=True,
+        )
+        db.add(donor)
+
     db.commit()
 
     posts = [
@@ -37,7 +47,7 @@ def seed():
     db.commit()
     db.close()
     print("Database seeded.\n")
-    print("Login with admin/admin or user/password")
+    print("Login with admin/admin, user/password or donor/donor")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `is_donor` column to `User`
- allow register endpoint to set `is_donor`
- expose `is_donor` in user responses
- seed a donor demo account

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d91f2c0ac8320bcb1e9667708ab26