### PR TITLE
Add dashboard page

### DIFF
--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { fetchJson } from '../../util/api';
+
+export default function DashboardPage() {
+  const [user, setUser] = useState(null);
+  const [tab, setTab] = useState('Profile');
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+
+  useEffect(() => {
+    if (!token) return;
+    fetchJson('/users/me', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(setUser)
+      .catch(() => setUser(null));
+  }, [token]);
+
+  if (!token) return <p>Please login.</p>;
+  if (!user) return <p>Loading...</p>;
+
+  const tabs = ['Profile'];
+  if (user.is_donor) tabs.push('Posts');
+  if (user.is_admin) tabs.push('Admin');
+
+  const renderTab = () => {
+    switch (tab) {
+      case 'Profile':
+        return <p>Your profile details will appear here.</p>;
+      case 'Posts':
+        return <p>Post management coming soon.</p>;
+      case 'Admin':
+        return <p>Admin tools coming soon.</p>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <nav style={{ marginBottom: 20 }}>
+        {tabs.map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            style={{ marginRight: 8, fontWeight: tab === t ? 'bold' : 'normal' }}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+      {renderTab()}
+    </div>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -17,7 +17,7 @@ export default function LoginPage() {
     if (res.ok) {
       const data = await res.json();
       localStorage.setItem('token', data.access_token);
-      router.push('/posts');
+      router.push('/dashboard');
     } else {
       alert('Login failed');
     }


### PR DESCRIPTION
## Summary
- add dashboard page with simple role-based menu
- fetch user details from `/users/me`
- redirect to dashboard after login

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d93ce3e448320b998ce31dca1d8f8