### PR TITLE
Add unified dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ This creates two accounts:
 
 ## Running the application
 
-Start both servers in development mode:
+Run the helper script to install dependencies and launch the servers:
 
 ```bash
-npm run dev
+./scripts/dev.sh
 ```
 
 The frontend runs on port 3000 and uses environment variables to reach the backend on port 8000.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Move to repository root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Install Node.js dependencies
+if [ ! -d node_modules ]; then
+  npm install --legacy-peer-deps
+fi
+
+# Set up Python virtual environment
+if [ ! -d backend/venv ]; then
+  python3 -m venv backend/venv
+  source backend/venv/bin/activate
+  pip install -r backend/requirements.txt
+  pip install -r backend/requirements-dev.txt
+else
+  source backend/venv/bin/activate
+fi
+
+# Start Next.js and FastAPI
+npm run dev


### PR DESCRIPTION
## Summary
- automate initial setup and server startup via `scripts/dev.sh`
- document usage of the helper script in the README

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d980c44508320bdedf537ae9123fc