### PR TITLE
Add dashboard tests and backend route coverage

### DIFF
--- a/components/DashaChart.test.jsx
+++ b/components/DashaChart.test.jsx
@@ -1,7 +1,11 @@
-import React from "react";
+import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import DashaChart from './DashaChart';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <canvas data-testid="chart" />
+}));
 
 const sample = [
   { lord: 'Sun', start: '2020-01-01', end: '2021-01-01' },

--- a/components/DashboardPage.test.jsx
+++ b/components/DashboardPage.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import DashboardPage from '../pages/dashboard/index.jsx';
+
+import { fetchJson } from '../util/api';
+vi.mock('../util/api', () => ({
+  fetchJson: vi.fn()
+}));
+
+function setupToken(token) {
+  if (token) {
+    window.localStorage.setItem('token', token);
+  } else {
+    window.localStorage.removeItem('token');
+  }
+}
+
+test('prompts to login when no token', () => {
+  setupToken(null);
+  render(<DashboardPage />);
+  expect(screen.getByText(/please login/i)).toBeDefined();
+});
+
+test('shows dashboard after loading user', async () => {
+  setupToken('t');
+  fetchJson.mockResolvedValue({ username: 'u', is_admin: true, is_donor: true });
+  render(<DashboardPage />);
+  await screen.findByText('Dashboard');
+  expect(screen.getByText('Admin')).toBeDefined();
+  expect(screen.getByText('Posts')).toBeDefined();
+});

--- a/pages/dashboard/index.jsx
+++ b/pages/dashboard/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { fetchJson } from '../../util/api';
 
 export default function DashboardPage() {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -270,3 +270,38 @@ def test_admin_metrics_and_donor_endpoints():
     resp = client.get("/reports", headers={"Authorization": f"Bearer {token_donor}"})
     assert resp.status_code == 200 and resp.json() == {"reports": []}
 
+
+def test_yogas_route(monkeypatch):
+    monkeypatch.setattr(main, "compute_vedic_profile", lambda req: {
+        "yogas": {"TestYoga": {}},
+        "analysis": {"yogas": {"TestYoga": {}}}
+    })
+    resp = client.post(
+        "/yogas",
+        json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"},
+    )
+    assert resp.status_code == 200
+    data = _parse_response(resp.json())
+    assert data.yogas == {"TestYoga": {}}
+    assert data.analysis == {"TestYoga": {}}
+
+
+def test_strengths_route(monkeypatch):
+    monkeypatch.setattr(main, "compute_vedic_profile", lambda req: {
+        "shadbala": {"Sun": 1},
+        "bhavaBala": {"1": 10}
+    })
+    resp = client.post(
+        "/strengths",
+        json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"},
+    )
+    assert resp.status_code == 200
+    data = _parse_response(resp.json())
+    assert data.shadbala == {"Sun": 1}
+    assert data.bhavaBala == {"1": 10}
+
+
+def test_health_route():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    include: ['components/**/*.test.{js,jsx}'],
+    include: ['components/**/*.test.{js,jsx}', 'pages/**/*.test.{js,jsx}'],
     coverage: {
       reporter: ['text', 'html'],
       reportsDirectory: 'coverage'


### PR DESCRIPTION
## Summary
- mock chart component in DashaChart tests
- add DashboardPage tests
- expose dashboard page as JSX and adjust imports
- include page tests in vitest config
- cover yogas, strengths and health routes with pytest

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_685d99175bf48320a17af5618dabfc74