### PR TITLE
Add landing page and profile route

### DIFF
--- a/components/LandingPage.jsx
+++ b/components/LandingPage.jsx
@@ -1,0 +1,17 @@
+// Hero landing section with login and scroll options
+
+import React from 'react';
+import Link from 'next/link';
+
+export default function LandingPage() {
+  return (
+    <section className="mb-10 text-center">
+      <h1 className="text-4xl font-bold mb-4">Cosmic Dharma</h1>
+      <p className="mb-6">Delve into Vedic astrology and discover new insights.</p>
+      <div className="flex justify-center gap-4">
+        <Link href="/login" className="glass-button">Login</Link>
+        <a href="#about" className="glass-button">Scroll to Read</a>
+      </div>
+    </section>
+  );
+}

--- a/components/LandingPage.test.jsx
+++ b/components/LandingPage.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import LandingPage from './LandingPage';
+
+test('renders hero and navigation links', () => {
+  render(<LandingPage />);
+  expect(screen.getByText(/cosmic dharma/i)).toBeDefined();
+  const login = screen.getByRole('link', { name: /login/i });
+  expect(login.getAttribute('href')).toBe('/login');
+  const read = screen.getByRole('link', { name: /scroll to read/i });
+  expect(read.getAttribute('href')).toBe('#about');
+});

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,83 +1,13 @@
-import { useState, useEffect } from 'react';
-import { fetchJson } from '../util/api';
-import ProfileForm from '../components/ProfileForm';
-import BasicInfo from '../components/BasicInfo';
-import ProfileSummary from '../components/ProfileSummary';
-import CoreElements from '../components/CoreElements';
-import PlanetTable from '../components/PlanetTable';
-import HouseAnalysis from '../components/HouseAnalysis';
-import DashaTable from '../components/DashaTable';
-import DashaChart from '../components/DashaChart';
+import LandingPage from '../components/LandingPage';
 
 export default function HomePage() {
-  const [form, setForm] = useState({ name: '', birthDate: '', birthTime: '', location: '' });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [profile, setProfile] = useState(null);
-  const [jobId, setJobId] = useState(null);
-
-  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
-
-  const handleSubmit = async e => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    try {
-      const data = await fetchJson('/profile/job', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          date: form.birthDate,
-          time: form.birthTime,
-          location: form.location,
-        }),
-      });
-      setJobId(data.job_id);
-    } catch (err) {
-      setError(err.message);
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!jobId) return;
-    const id = setInterval(async () => {
-      try {
-        const data = await fetchJson(`/jobs/${jobId}`);
-        if (data.status === 'complete') {
-          setProfile({ ...data.result, request: form });
-          setJobId(null);
-          setLoading(false);
-        } else if (data.status === 'error') {
-          setError(data.error || 'Job failed');
-          setJobId(null);
-          setLoading(false);
-        }
-      } catch (err) {
-        setError(err.message);
-        setJobId(null);
-        setLoading(false);
-      }
-    }, 1000);
-    return () => clearInterval(id);
-  }, [jobId, form]);
-
   return (
     <main className="page-wrapper">
-      <h1>Vedic Astrology</h1>
-      <ProfileForm form={form} onChange={handleChange} onSubmit={handleSubmit} loading={loading} />
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      {profile && (
-        <section>
-          <BasicInfo birth={{ ...profile.birthInfo, ...form }} />
-          <ProfileSummary analysis={profile.analysis} />
-          <CoreElements analysis={profile.analysis} elements={profile.coreElements} />
-          <PlanetTable planets={profile.planetaryPositions} />
-          <HouseAnalysis houses={profile.analysis?.houses || profile.houses} />
-          <DashaTable dasha={profile.vimshottariDasha} />
-          <DashaChart dasha={profile.vimshottariDasha} analysis={profile.analysis?.vimshottariDasha} />
-        </section>
-      )}
+      <LandingPage />
+      <section id="about" className="mt-10">
+        <h2>About Cosmic Dharma</h2>
+        <p>Read our latest posts and learn about Vedic astrology.</p>
+      </section>
     </main>
   );
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { fetchJson } from '../util/api';
+import ProfileForm from '../components/ProfileForm';
+import BasicInfo from '../components/BasicInfo';
+import ProfileSummary from '../components/ProfileSummary';
+import CoreElements from '../components/CoreElements';
+import PlanetTable from '../components/PlanetTable';
+import HouseAnalysis from '../components/HouseAnalysis';
+import DashaTable from '../components/DashaTable';
+import DashaChart from '../components/DashaChart';
+
+export default function ProfilePage() {
+  const [form, setForm] = useState({ name: '', birthDate: '', birthTime: '', location: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [profile, setProfile] = useState(null);
+  const [jobId, setJobId] = useState(null);
+
+  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchJson('/profile/job', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          date: form.birthDate,
+          time: form.birthTime,
+          location: form.location,
+        }),
+      });
+      setJobId(data.job_id);
+    } catch (err) {
+      setError(err.message);
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!jobId) return;
+    const id = setInterval(async () => {
+      try {
+        const data = await fetchJson(`/jobs/${jobId}`);
+        if (data.status === 'complete') {
+          setProfile({ ...data.result, request: form });
+          setJobId(null);
+          setLoading(false);
+        } else if (data.status === 'error') {
+          setError(data.error || 'Job failed');
+          setJobId(null);
+          setLoading(false);
+        }
+      } catch (err) {
+        setError(err.message);
+        setJobId(null);
+        setLoading(false);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [jobId, form]);
+
+  return (
+    <main className="page-wrapper">
+      <h1>Vedic Astrology</h1>
+      <ProfileForm form={form} onChange={handleChange} onSubmit={handleSubmit} loading={loading} />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {profile && (
+        <section>
+          <BasicInfo birth={{ ...profile.birthInfo, ...form }} />
+          <ProfileSummary analysis={profile.analysis} />
+          <CoreElements analysis={profile.analysis} elements={profile.coreElements} />
+          <PlanetTable planets={profile.planetaryPositions} />
+          <HouseAnalysis houses={profile.analysis?.houses || profile.houses} />
+          <DashaTable dasha={profile.vimshottariDasha} />
+          <DashaChart dasha={profile.vimshottariDasha} analysis={profile.analysis?.vimshottariDasha} />
+        </section>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create LandingPage hero component
- replace index profile form with LandingPage and about section
- move horoscope profile logic to `pages/profile.js`
- test LandingPage rendering

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da12a0bf4832088785e5f8554c1d7