### PR TITLE
Add login tests

### DIFF
--- a/components/LoginPage.test.tsx
+++ b/components/LoginPage.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import LoginPage from '../pages/login';
+import apiFetch from '../util/api';
+
+vi.mock('../util/api', () => ({
+  default: vi.fn()
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}));
+
+test('submits credentials via apiFetch', async () => {
+  const fetchMock = apiFetch as any;
+  fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ access_token: 't' }) });
+  render(<LoginPage />);
+  fireEvent.change(screen.getByPlaceholderText(/username/i), { target: { value: 'u' } });
+  fireEvent.change(screen.getByPlaceholderText(/password/i), { target: { value: 'p' } });
+  fireEvent.click(screen.getByRole('button', { name: /login/i }));
+  expect(apiFetch).toHaveBeenCalledWith('login', expect.any(Object));
+});

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import apiFetch from '../util/api';
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,57 @@
+from fastapi.testclient import TestClient
+from backend import main, models, auth
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import sqlalchemy
+
+
+def setup_test_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    TestingSession = sessionmaker(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+
+    def override():
+        db = TestingSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    main.app.dependency_overrides[main.get_session] = override
+    main.app.dependency_overrides[auth.get_session] = override
+    return TestClient(main.app), TestingSession
+
+
+def test_login_valid():
+    client, Session = setup_test_app()
+    with Session() as db:
+        user = models.User(
+            username="test",
+            email="t@example.com",
+            hashed_password=auth.get_password_hash("pw"),
+        )
+        db.add(user)
+        db.commit()
+
+    resp = client.post("/login", data={"username": "test", "password": "pw"})
+    assert resp.status_code == 200
+    assert "access_token" in resp.json()
+
+
+def test_login_invalid():
+    client, Session = setup_test_app()
+    with Session() as db:
+        user = models.User(
+            username="user",
+            email="u@example.com",
+            hashed_password=auth.get_password_hash("pw"),
+        )
+        db.add(user)
+        db.commit()
+
+    resp = client.post("/login", data={"username": "user", "password": "bad"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- test FastAPI /login endpoint
- check LoginPage submits credentials with apiFetch
- import React in login page for tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da55bc5dc8320b778d82afce27f9b