### PR TITLE
Update dashboard with posts and admin tools

### DIFF
--- a/components/DashboardPage.test.tsx
+++ b/components/DashboardPage.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import DashboardPage from '../pages/dashboard/index';
 
 import { fetchJson } from '../util/api';
 vi.mock('../util/api', () => ({
-  fetchJson: vi.fn()
+  fetchJson: vi.fn(),
+  default: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
 }));
 
 function setupToken(token) {
@@ -17,16 +18,42 @@ function setupToken(token) {
 }
 
 test('prompts to login when no token', () => {
+  fetchJson.mockReset();
   setupToken(null);
   render(<DashboardPage />);
   expect(screen.getByText(/please login/i)).toBeDefined();
 });
 
 test('shows dashboard after loading user', async () => {
+  fetchJson.mockReset();
   setupToken('t');
   fetchJson.mockResolvedValue({ username: 'u', is_admin: true, is_donor: true });
   render(<DashboardPage />);
-  await screen.findByText('Dashboard');
+  await screen.findAllByText('Dashboard');
   expect(screen.getByText('Admin')).toBeDefined();
   expect(screen.getByText('Posts')).toBeDefined();
+});
+
+test('renders post list for donors', async () => {
+  fetchJson.mockReset();
+  setupToken('t');
+  fetchJson
+    .mockResolvedValueOnce({ username: 'u', is_donor: true })
+    .mockResolvedValueOnce([{ id: 1, title: 'Hello' }]);
+  render(<DashboardPage />);
+  await screen.findAllByText('Dashboard');
+  fireEvent.click(screen.getAllByText('Posts')[0]);
+  await screen.findByText(/blog posts/i);
+});
+
+test('renders admin dashboard for admins', async () => {
+  fetchJson.mockReset();
+  setupToken('t');
+  fetchJson
+    .mockResolvedValueOnce({ username: 'u', is_admin: true })
+    .mockResolvedValueOnce([]); // posts fetch will not be used
+  render(<DashboardPage />);
+  await screen.findAllByText('Dashboard');
+  fireEvent.click(screen.getAllByText('Admin')[0]);
+  await screen.findByText(/admin dashboard/i);
 });

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import apiFetch from '../util/api';
+
+export interface BlogPost {
+  id: number;
+  title: string;
+}
+
+export interface PostListProps {
+  posts?: BlogPost[];
+}
+
+export default function PostList({ posts: initialPosts }: PostListProps = {}) {
+  const [posts, setPosts] = useState<BlogPost[]>(initialPosts ?? []);
+
+  useEffect(() => {
+    if (initialPosts) return;
+    apiFetch('posts')
+      .then(res => res.json())
+      .then(data => setPosts(data))
+      .catch(() => setPosts([]));
+  }, [initialPosts]);
+
+  return (
+    <div>
+      <h2>Blog Posts</h2>
+      <Link href="/editor">New Post</Link>
+      <ul>
+        {(Array.isArray(posts) ? posts : []).map(p => (
+          <li key={p.id}>
+            <Link href={`/posts/${p.id}`}>{p.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { fetchJson } from '../../util/api';
+import PostList, { BlogPost } from '../../components/PostList';
+import AdminDashboard from '../../components/AdminDashboard';
 
 interface DashboardUser {
   is_admin?: boolean;
@@ -9,6 +11,7 @@ interface DashboardUser {
 
 export default function DashboardPage() {
   const [user, setUser] = useState<DashboardUser | null>(null);
+  const [posts, setPosts] = useState<BlogPost[]>([]);
   const [tab, setTab] = useState<string>('Profile');
   const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
 
@@ -20,6 +23,15 @@ export default function DashboardPage() {
       .then(setUser)
       .catch(() => setUser(null));
   }, [token]);
+
+  useEffect(() => {
+    if (!token || !user?.is_donor) return;
+    fetchJson<BlogPost[]>('posts', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(setPosts)
+      .catch(() => setPosts([]));
+  }, [token, user]);
 
   if (!token) return <p>Please login.</p>;
   if (!user) return <p>Loading...</p>;
@@ -33,9 +45,9 @@ export default function DashboardPage() {
       case 'Profile':
         return <p>Your profile details will appear here.</p>;
       case 'Posts':
-        return <p>Post management coming soon.</p>;
+        return <PostList posts={posts} />;
       case 'Admin':
-        return <p>Admin tools coming soon.</p>;
+        return <AdminDashboard />;
       default:
         return null;
     }

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -1,33 +1,9 @@
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import apiFetch from '../../util/api';
-
-interface BlogPost {
-  id: number;
-  title: string;
-}
+import PostList from '../../components/PostList';
 
 export default function PostListPage() {
-  const [posts, setPosts] = useState<BlogPost[]>([]);
-
-  useEffect(() => {
-    apiFetch('posts')
-      .then(res => res.json())
-      .then(data => setPosts(data))
-      .catch(() => setPosts([]));
-  }, []);
-
   return (
     <div>
-      <h2>Blog Posts</h2>
-      <Link href="/editor">New Post</Link>
-      <ul>
-        {posts.map(p => (
-          <li key={p.id}>
-            <Link href={`/posts/${p.id}`}>{p.title}</Link>
-          </li>
-        ))}
-      </ul>
+      <PostList />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create reusable `PostList` component and use it from posts page
- display donor posts and admin metrics on the dashboard
- fetch posts for authorized donors only
- update dashboard tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dad98e524832088b5d1fa0d7d60bd