### PR TITLE
Fix Netlify install flags

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "npm run build"
   publish = ".next"
-  environment = { NODE_VERSION = "18" }
+  environment = { NODE_VERSION = "18", NPM_FLAGS = "--legacy-peer-deps" }
 
 [context.production.environment]
   # Set the backend API URL in Netlify settings or override here


### PR DESCRIPTION
## Summary
- add `NPM_FLAGS` in Netlify config so builds use `--legacy-peer-deps`

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db0b34c9c832093fe51e6461a9fd3