### PR TITLE
Add donor prompt and report models

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -19,6 +19,8 @@ class User(Base):
     )
 
     posts = relationship("BlogPost", back_populates="owner")
+    prompts = relationship("Prompt", back_populates="user")
+    reports = relationship("Report", back_populates="user")
 
 
 class BlogPost(Base):
@@ -34,3 +36,25 @@ class BlogPost(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 
     owner = relationship("User", back_populates="posts")
+
+
+class Prompt(Base):
+    __tablename__ = "prompts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    text = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    user = relationship("User", back_populates="prompts")
+
+
+class Report(Base):
+    __tablename__ = "reports"
+
+    id = Column(Integer, primary_key=True, index=True)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    user = relationship("User", back_populates="reports")


### PR DESCRIPTION
## Summary
- implement Prompt and Report models
- create donor endpoints for prompts and reports
- test donor-only CRUD operations

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db0b96bec8320a593478947b3e23b