### PR TITLE
Add Redis-backed job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ reads these environment variables:
 * `NODE_TYPE` – lunar node calculation (`mean` or `true`).
 * `HOUSE_SYSTEM` – astrological house system (`whole_sign` by default).
 * `CACHE_ENABLED` – enable or disable caching.
+* `REDIS_URL` – connection string for Redis used by the background job queue.
 
 To seed the database with demo accounts and posts run from the repository root:
 
@@ -72,6 +73,13 @@ After the initial setup you can simply run:
 npm run dev
 ```
 to start the Next.js frontend and FastAPI backend concurrently.
+
+Background profile jobs are handled by an RQ worker. Start one in a
+separate terminal:
+
+```bash
+rq worker profiles
+```
 
 The frontend runs on port 3000 and uses environment variables to reach the backend on port 8000.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,6 +7,7 @@ DEFAULTS = {
     "node_type": "mean",
     "house_system": "whole_sign",
     "cache_enabled": "true",
+    "redis_url": "redis://localhost:6379/0",
 }
 
 _cfg = None

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -3,3 +3,4 @@ ayanamsa: lahiri  # Changed from fagan_bradley to lahiri (standard for Vedic)
 node_type: mean   # This is correct for Vedic
 house_system: whole_sign  # Changed from placidus to whole_sign (traditional Vedic)
 cache_enabled: true
+redis_url: redis://localhost:6379/0

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -16,3 +16,6 @@ passlib[bcrypt]>=1.7.4
 bcrypt<4.0
 python-jose[cryptography]
 python-multipart
+redis
+rq
+fakeredis

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,5 @@ passlib[bcrypt]>=1.7.4
 bcrypt<4.0
 python-jose[cryptography]
 python-multipart
+redis
+rq

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,27 @@
+import datetime
+from fastapi import BackgroundTasks
+import fakeredis
+from rq import Queue, SimpleWorker
+from backend.services import astro
+
+
+def fake_compute(req):
+    return {'done': True}
+
+
+def test_enqueue_and_get_job(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    q = Queue('profiles', connection=fake)
+    monkeypatch.setattr(astro, '_REDIS', fake)
+    monkeypatch.setattr(astro, '_JOB_QUEUE', q)
+    monkeypatch.setattr(astro, 'compute_vedic_profile', fake_compute)
+
+    req = astro.ProfileRequest(date=datetime.date(2020, 1, 1), time=datetime.time(12, 0), location='Delhi')
+    job_id = astro.enqueue_profile_job(req, BackgroundTasks())
+
+    worker = SimpleWorker([q], connection=fake)
+    worker.work(burst=True)
+
+    job = astro.get_job(job_id)
+    assert job['status'] == 'complete'
+    assert job['result'] == {'done': True}


### PR DESCRIPTION
## Summary
- use Redis+RQ for persistent jobs
- expose redis_url in config
- document running RQ worker
- add test exercising Redis queue

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db28ac5948320a368c81de1e55dd9