### PR TITLE
Add navbar with auth-aware links

### DIFF
--- a/components/Navbar.test.tsx
+++ b/components/Navbar.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import Navbar from './Navbar';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}));
+
+function setToken(token: string | null) {
+  if (token) {
+    window.localStorage.setItem('token', token);
+  } else {
+    window.localStorage.removeItem('token');
+  }
+}
+
+test('shows login link when logged out', () => {
+  setToken(null);
+  render(<Navbar />);
+  expect(screen.getByRole('link', { name: /home/i })).toBeDefined();
+  expect(screen.getByRole('link', { name: /posts/i })).toBeDefined();
+  expect(screen.getByRole('link', { name: /dashboard/i })).toBeDefined();
+  expect(screen.getByRole('link', { name: /login/i })).toBeDefined();
+  expect(screen.queryByRole('button', { name: /logout/i })).toBeNull();
+});
+
+test('shows logout button when logged in', async () => {
+  setToken('t');
+  render(<Navbar />);
+  await screen.findByRole('button', { name: /logout/i });
+  expect(screen.getByRole('button', { name: /logout/i })).toBeDefined();
+});

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function Navbar() {
+  const router = useRouter();
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    setAuthed(!!token);
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setAuthed(false);
+    router.push('/');
+  };
+
+  return (
+    <nav className="bg-gray-200 p-4 mb-4">
+      <ul className="flex gap-4">
+        <li>
+          <Link href="/">Home</Link>
+        </li>
+        <li>
+          <Link href="/posts">Posts</Link>
+        </li>
+        <li>
+          <Link href="/dashboard">Dashboard</Link>
+        </li>
+        <li>
+          {authed ? (
+            <button onClick={handleLogout}>Logout</button>
+          ) : (
+            <Link href="/login">Login</Link>
+          )}
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,12 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import Navbar from '../components/Navbar';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Navbar />
+      <Component {...pageProps} />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- add `Navbar` component with conditional login/logout
- include navbar in the app layout
- verify navbar links with new unit tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685db815b9c48320b94f83a383cb31f0