### PR TITLE
Implement password reset functionality

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -58,3 +58,18 @@ class Report(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 
     user = relationship("User", back_populates="reports")
+
+
+class PasswordResetToken(Base):
+    """Token model for password reset requests."""
+
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    token = Column(String, unique=True, index=True, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User")

--- a/backend/utils/email_utils.py
+++ b/backend/utils/email_utils.py
@@ -1,0 +1,35 @@
+import logging
+import os
+import smtplib
+from email.message import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+
+def send_email(to_email: str, subject: str, body: str) -> None:
+    """Send an email or log it if SMTP not configured."""
+    smtp_server = os.getenv("SMTP_SERVER")
+    smtp_port = int(os.getenv("SMTP_PORT", "25"))
+    smtp_user = os.getenv("SMTP_USER")
+    smtp_pass = os.getenv("SMTP_PASS")
+    from_addr = os.getenv("FROM_EMAIL", "noreply@example.com")
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_email
+    msg.set_content(body)
+
+    if not smtp_server:
+        logger.info("Email to %s: %s", to_email, body)
+        return
+
+    try:
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            if smtp_user and smtp_pass:
+                server.starttls()
+                server.login(smtp_user, smtp_pass)
+            server.send_message(msg)
+    except Exception as exc:  # pragma: no cover - smtp errors
+        logger.error("Failed to send email: %s", exc)
+        raise

--- a/pages/request-reset.tsx
+++ b/pages/request-reset.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import apiFetch from '../util/api';
+
+export default function RequestResetPage() {
+  const [email, setEmail] = useState('');
+  const [done, setDone] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await apiFetch('/request-reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    setDone(true);
+  };
+
+  if (done) return <p>Check your email for a reset token.</p>;
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">Reset Password</h2>
+      <input
+        name="email"
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border rounded p-2"
+      />
+      <button type="submit" className="rounded bg-blue-600 p-2 text-white">
+        Send Reset Link
+      </button>
+    </form>
+  );
+}

--- a/pages/reset-password.tsx
+++ b/pages/reset-password.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import apiFetch from '../util/api';
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ token: '', new_password: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await apiFetch('/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    if (res.ok) {
+      router.push('/login');
+    } else {
+      alert('Reset failed');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold">Set New Password</h2>
+      <input
+        name="token"
+        value={form.token}
+        onChange={handleChange}
+        placeholder="Token"
+        className="border rounded p-2"
+      />
+      <input
+        name="new_password"
+        type="password"
+        value={form.new_password}
+        onChange={handleChange}
+        placeholder="New Password"
+        className="border rounded p-2"
+      />
+      <button type="submit" className="rounded bg-blue-600 p-2 text-white">
+        Reset Password
+      </button>
+    </form>
+  );
+}

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+from backend import main, models, auth
+from backend.utils import email_utils
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import sqlalchemy
+
+
+def setup_test_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    TestingSession = sessionmaker(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+
+    def override():
+        db = TestingSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    main.app.dependency_overrides[main.get_session] = override
+    main.app.dependency_overrides[auth.get_session] = override
+    return TestClient(main.app), TestingSession
+
+
+def test_password_reset_flow(monkeypatch):
+    client, Session = setup_test_app()
+
+    sent = {}
+
+    def fake_send(to, subject, body):
+        sent["to"] = to
+        sent["body"] = body
+
+    monkeypatch.setattr(main, "send_email", fake_send)
+
+    with Session() as db:
+        user = models.User(
+            username="u1",
+            email="u1@example.com",
+            hashed_password=auth.get_password_hash("old"),
+        )
+        db.add(user)
+        db.commit()
+
+    resp = client.post("/request-reset", json={"email": "u1@example.com"})
+    assert resp.status_code == 200
+
+    with Session() as db:
+        token_obj = db.query(models.PasswordResetToken).first()
+        assert token_obj is not None
+        token_value = token_obj.token
+
+    assert sent["to"] == "u1@example.com"
+    assert token_value in sent["body"]
+
+    resp = client.post(
+        "/reset-password",
+        json={"token": token_value, "new_password": "newpass"},
+    )
+    assert resp.status_code == 200
+
+    with Session() as db:
+        user = db.query(models.User).first()
+        assert auth.verify_password("newpass", user.hashed_password)
+        token_obj = db.query(models.PasswordResetToken).first()
+        assert token_obj.used


### PR DESCRIPTION
## Summary
- add `PasswordResetToken` model
- implement password reset endpoints and email util
- create React pages to request and perform a reset
- test token creation and password reset workflow

## Testing
- `npm test`
- `PYTHONPATH=. pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685dba6a3e848320935a35d968084560