### PR TITLE
Add custom 404 page

### DIFF
--- a/components/NotFoundPage.test.tsx
+++ b/components/NotFoundPage.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import NotFoundPage from '../pages/404';
+
+test('renders friendly not found message', () => {
+  render(<NotFoundPage />);
+  expect(screen.getByText(/page not found/i)).toBeDefined();
+  const link = screen.getByRole('link', { name: /go back home/i });
+  expect(link.getAttribute('href')).toBe('/');
+});

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import Link from 'next/link';
+
+export default function NotFoundPage() {
+  return (
+    <main className="page-wrapper flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <h1 className="text-3xl font-semibold">Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
+      <Link href="/" className="text-blue-600 underline">
+        Go back home
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `pages/404.tsx` with a message and link home
- ensure styling with Tailwind
- add `NotFoundPage.test.tsx` to render the new page

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc07f838483208068015aae1c3178