### PR TITLE
Refactor backend API routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,59 +1,32 @@
-# backend/main.py - UPDATED WITH COMPLETE VEDIC FEATURES
-
 import logging
-from datetime import datetime, timedelta
-from secrets import token_urlsafe
-from fastapi import (
-    FastAPI,
-    HTTPException,
-    Depends,
-    Response,
-    BackgroundTasks,
-)
+from fastapi import FastAPI, HTTPException, Depends, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+from datetime import datetime
 
-from backend.db import Base, engine, get_session
-from backend.models import User, BlogPost, Prompt, Report, PasswordResetToken
-from backend.auth import (
-    create_access_token,
-    get_password_hash,
-    authenticate_user,
-    get_current_user,
-)
+from .db import Base, engine, get_session
+from .models import User, Prompt, Report
+from .auth import get_current_user
+from .routes import auth_router, profile_router, blog_router, admin_router
 
-from backend.services.astro import (
-    ProfileRequest,
-    ProfileResponse,
-    compute_vedic_profile,
-    enqueue_profile_job,
-    get_job,
-    clear_profile_cache,
-)
-from backend.config import load_config
-from backend.utils.email_utils import send_email
-
-CONFIG = load_config()
-
-# Setup basic logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-
-# FastAPI app init
 app = FastAPI(
     title="Vedic Astrology Service",
     description="Comprehensive Vedic astrology calculations following traditional principles",
-    version="2.0"
+    version="2.0",
 )
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"], allow_credentials=True,
-    allow_methods=["*"], allow_headers=["*"],
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 Base.metadata.create_all(bind=engine)
@@ -61,46 +34,14 @@ Base.metadata.create_all(bind=engine)
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request, exc):
-    """Return validation errors in a structured format."""
     logger.error("Validation error: %s", exc)
     return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
 
-
-class UserCreate(BaseModel):
-    username: str
-    email: str
-    password: str
-    is_donor: bool = False
-
-
-class Token(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
-
-
-class UserOut(BaseModel):
-    username: str
-    email: str
-    is_admin: bool
-    is_donor: bool
-
-
-class BlogPostCreate(BaseModel):
-    title: str
-    content: str
-
-
-class BlogPostOut(BaseModel):
-    id: int
-    title: str
-    content: str
-    created_at: datetime
-    updated_at: datetime
-    owner: str
-
-    class Config:
-        orm_mode = True
+app.include_router(auth_router)
+app.include_router(profile_router)
+app.include_router(blog_router)
+app.include_router(admin_router)
 
 
 class PromptCreate(BaseModel):
@@ -123,372 +64,19 @@ class ReportOut(BaseModel):
     created_at: datetime
 
 
-class ResetRequest(BaseModel):
-    email: str
-
-
-class PasswordReset(BaseModel):
-    token: str
-    new_password: str
-
-
-
-@app.post("/profile", response_model=ProfileResponse)
-async def get_profile(request: ProfileRequest):
-    """Get complete Vedic astrological profile."""
-    logger.info("Received profile request: %s", request)
-    try:
-        result = compute_vedic_profile(request)
-        logger.info("Profile computation completed")
-        return result
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception("Unhandled error")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.post("/profile/job")
-async def start_profile_job(request: ProfileRequest, background_tasks: BackgroundTasks):
-    """Start background profile computation and return a job ID."""
-    job_id = enqueue_profile_job(request, background_tasks)
-    return {"job_id": job_id}
-
-
-@app.get("/jobs/{job_id}")
-async def get_job_result(job_id: str):
-    """Retrieve status or result for a previously started job."""
-    job = get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
-    return job
-
-
-@app.post("/divisional-charts", response_model=ProfileResponse)
-async def get_divisional_charts(request: ProfileRequest):
-    """Return all 16 main divisional charts based on profile input."""
-    logger.info("Received divisional charts request: %s", request)
-    data = compute_vedic_profile(request)
-    logger.info("Divisional charts computation completed")
-    return {"divisionalCharts": data["divisionalCharts"]}
-
-
-@app.post("/dasha", response_model=ProfileResponse)
-async def get_dasha(request: ProfileRequest):
-    """Return Vimshottari dasha with sub-periods."""
-    logger.info("Received dasha request: %s", request)
-    data = compute_vedic_profile(request)
-    logger.info("Dasha computation completed")
-    return {"vimshottariDasha": data["vimshottariDasha"]}
-
-
-@app.post("/yogas", response_model=ProfileResponse)
-async def get_yogas(request: ProfileRequest):
-    """Return all planetary combinations (yogas) in the chart."""
-    logger.info("Received yogas request: %s", request)
-    data = compute_vedic_profile(request)
-    logger.info("Yogas computation completed")
-    return {
-        "yogas": data["yogas"],
-        "analysis": data["analysis"]["yogas"]
-    }
-
-
-@app.post("/strengths", response_model=ProfileResponse)
-async def get_strengths(request: ProfileRequest):
-    """Return planetary and house strengths."""
-    logger.info("Received strengths request: %s", request)
-    data = compute_vedic_profile(request)
-    logger.info("Strengths computation completed")
-    return {
-        "shadbala": data["shadbala"],
-        "bhavaBala": data["bhavaBala"]
-    }
-
-
-@app.get("/health")
-async def health_check():
-    """Health check endpoint."""
-    return {"status": "healthy", "version": "2.0"}
-
-
-@app.post("/register", response_model=Token)
-def register(user: UserCreate, db: Session = Depends(get_session)):
-    if db.query(User).filter(
-        (User.username == user.username) | (User.email == user.email)
-    ).first():
-        raise HTTPException(status_code=400, detail="User already exists")
-    db_user = User(
-        username=user.username,
-        email=user.email,
-        hashed_password=get_password_hash(user.password),
-        is_donor=user.is_donor,
-    )
-    db.add(db_user)
-    db.commit()
-    db.refresh(db_user)
-    token = create_access_token({"sub": db_user.username})
-    return {"access_token": token, "token_type": "bearer"}
-
-
-@app.post("/login", response_model=Token)
-def login(
-    form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Session = Depends(get_session),
-):
-    user = authenticate_user(db, form_data.username, form_data.password)
-    if not user:
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
-    token = create_access_token({"sub": user.username})
-    return {"access_token": token, "token_type": "bearer"}
-
-
-@app.post("/logout")
-def logout():
-    return {"message": "Logged out"}
-
-
-@app.post("/request-reset")
-def request_password_reset(
-    payload: ResetRequest,
-    db: Session = Depends(get_session),
-):
-    user = db.query(User).filter(User.email == payload.email).first()
-    if not user:
-        return {"message": "If the email exists, a reset link was sent."}
-    token = token_urlsafe(32)
-    expires = datetime.utcnow() + timedelta(hours=1)
-    db_token = PasswordResetToken(user_id=user.id, token=token, expires_at=expires)
-    db.add(db_token)
-    db.commit()
-    send_email(user.email, "Password Reset", f"Your reset token is: {token}")
-    return {"message": "If the email exists, a reset link was sent."}
-
-
-@app.post("/reset-password")
-def reset_password(
-    payload: PasswordReset,
-    db: Session = Depends(get_session),
-):
-    db_token = (
-        db.query(PasswordResetToken)
-        .filter(
-            PasswordResetToken.token == payload.token,
-            PasswordResetToken.used.is_(False),
-        )
-        .first()
-    )
-    if not db_token or db_token.expires_at < datetime.utcnow():
-        raise HTTPException(status_code=400, detail="Invalid or expired token")
-    user = db.query(User).get(db_token.user_id)
-    user.hashed_password = get_password_hash(payload.new_password)
-    db_token.used = True
-    db.commit()
-    return {"message": "Password updated"}
-
-
-@app.get("/users/me", response_model=UserOut)
-def read_current_user(current_user: User = Depends(get_current_user)):
-    return UserOut(
-        username=current_user.username,
-        email=current_user.email,
-        is_admin=current_user.is_admin,
-        is_donor=current_user.is_donor,
-    )
-
-
-@app.post("/posts", response_model=BlogPostOut)
-def create_post(
-    post: BlogPostCreate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_session),
-):
-    db_post = BlogPost(title=post.title, content=post.content, owner=current_user)
-    db.add(db_post)
-    db.commit()
-    db.refresh(db_post)
-    return BlogPostOut(
-        id=db_post.id,
-        title=db_post.title,
-        content=db_post.content,
-        created_at=db_post.created_at,
-        updated_at=db_post.updated_at,
-        owner=current_user.username,
-    )
-
-
-@app.get("/posts", response_model=list[BlogPostOut])
-def list_posts(db: Session = Depends(get_session)):
-    posts = db.query(BlogPost).order_by(BlogPost.created_at.desc()).all()
-    return [
-        BlogPostOut(
-            id=p.id,
-            title=p.title,
-            content=p.content,
-            created_at=p.created_at,
-            updated_at=p.updated_at,
-            owner=p.owner.username,
-        )
-        for p in posts
-    ]
-
-
-@app.get("/posts/{post_id}", response_model=BlogPostOut)
-def get_post(post_id: int, db: Session = Depends(get_session)):
-    p = db.query(BlogPost).get(post_id)
-    if not p:
-        raise HTTPException(status_code=404, detail="Post not found")
-    return BlogPostOut(
-        id=p.id,
-        title=p.title,
-        content=p.content,
-        created_at=p.created_at,
-        updated_at=p.updated_at,
-        owner=p.owner.username,
-    )
-
-
-@app.put("/posts/{post_id}", response_model=BlogPostOut)
-def update_post(
-    post_id: int,
-    post: BlogPostCreate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_session),
-):
-    db_post = db.query(BlogPost).get(post_id)
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    if db_post.user_id != current_user.id and not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Not allowed")
-    db_post.title = post.title
-    db_post.content = post.content
-    db.commit()
-    db.refresh(db_post)
-    return BlogPostOut(
-        id=db_post.id,
-        title=db_post.title,
-        content=db_post.content,
-        created_at=db_post.created_at,
-        updated_at=db_post.updated_at,
-        owner=current_user.username,
-    )
-
-
-@app.delete("/posts/{post_id}", status_code=204)
-def delete_post(
-    post_id: int,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_session),
-):
-    db_post = db.query(BlogPost).get(post_id)
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    if db_post.user_id != current_user.id and not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Not allowed")
-    db.delete(db_post)
-    db.commit()
-    return Response(status_code=204)
-
-
-def require_admin(current_user: User = Depends(get_current_user)) -> User:
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
-    return current_user
-
-
-@app.get("/admin/posts", response_model=list[BlogPostOut])
-def admin_list_posts(
-    current_user: User = Depends(require_admin),
-    db: Session = Depends(get_session),
-):
-    posts = db.query(BlogPost).order_by(BlogPost.created_at.desc()).all()
-    return [
-        BlogPostOut(
-            id=p.id,
-            title=p.title,
-            content=p.content,
-            created_at=p.created_at,
-            updated_at=p.updated_at,
-            owner=p.owner.username,
-        )
-        for p in posts
-    ]
-
-
-@app.put("/admin/posts/{post_id}", response_model=BlogPostOut)
-def admin_update_post(
-    post_id: int,
-    post: BlogPostCreate,
-    current_user: User = Depends(require_admin),
-    db: Session = Depends(get_session),
-):
-    db_post = db.get(BlogPost, post_id)
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    db_post.title = post.title
-    db_post.content = post.content
-    db.commit()
-    db.refresh(db_post)
-    return BlogPostOut(
-        id=db_post.id,
-        title=db_post.title,
-        content=db_post.content,
-        created_at=db_post.created_at,
-        updated_at=db_post.updated_at,
-        owner=db_post.owner.username,
-    )
-
-
-@app.delete("/admin/posts/{post_id}", status_code=204)
-def admin_delete_post(
-    post_id: int,
-    current_user: User = Depends(require_admin),
-    db: Session = Depends(get_session),
-):
-    db_post = db.get(BlogPost, post_id)
-    if not db_post:
-        raise HTTPException(status_code=404, detail="Post not found")
-    db.delete(db_post)
-    db.commit()
-    return Response(status_code=204)
-
-
-@app.get("/admin/users", response_model=list[UserOut])
-def admin_list_users(
-    current_user: User = Depends(require_admin),
-    db: Session = Depends(get_session),
-):
-    """Return all registered users for admin dashboard."""
-    users = db.query(User).order_by(User.created_at.desc()).all()
-    return [
-        UserOut(
-            username=u.username,
-            email=u.email,
-            is_admin=u.is_admin,
-            is_donor=u.is_donor,
-        )
-        for u in users
-    ]
-
-
-@app.get("/admin/metrics")
-def admin_metrics(
-    current_user: User = Depends(require_admin),
-    db: Session = Depends(get_session),
-):
-    """Return basic counts for the admin dashboard."""
-    return {
-        "users": db.query(User).count(),
-        "posts": db.query(BlogPost).count(),
-        "donors": db.query(User).filter(User.is_donor.is_(True)).count(),
-    }
+from datetime import datetime  # placed after BaseModel definitions
 
 
 def require_donor(current_user: User = Depends(get_current_user)) -> User:
     if not (current_user.is_donor or current_user.is_admin):
         raise HTTPException(status_code=403, detail="Donor access required")
     return current_user
+
+
+@app.get("/health")
+async def health_check():
+    return {"status": "healthy", "version": "2.0"}
+
 
 @app.post("/prompts", response_model=PromptOut)
 def create_prompt(

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,11 @@
+from .auth import router as auth_router
+from .profile import router as profile_router
+from .blog import router as blog_router
+from .admin import router as admin_router
+
+__all__ = [
+    "auth_router",
+    "profile_router",
+    "blog_router",
+    "admin_router",
+]

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -1,0 +1,104 @@
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.orm import Session
+
+from ..db import get_session
+from ..models import BlogPost, User
+from ..auth import get_current_user
+from .blog import BlogPostCreate, BlogPostOut
+from .auth import UserOut
+
+router = APIRouter()
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
+
+
+@router.get("/admin/posts", response_model=list[BlogPostOut])
+def admin_list_posts(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_session),
+):
+    posts = db.query(BlogPost).order_by(BlogPost.created_at.desc()).all()
+    return [
+        BlogPostOut(
+            id=p.id,
+            title=p.title,
+            content=p.content,
+            created_at=p.created_at,
+            updated_at=p.updated_at,
+            owner=p.owner.username,
+        )
+        for p in posts
+    ]
+
+
+@router.put("/admin/posts/{post_id}", response_model=BlogPostOut)
+def admin_update_post(
+    post_id: int,
+    post: BlogPostCreate,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_session),
+):
+    db_post = db.get(BlogPost, post_id)
+    if not db_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    db_post.title = post.title
+    db_post.content = post.content
+    db.commit()
+    db.refresh(db_post)
+    return BlogPostOut(
+        id=db_post.id,
+        title=db_post.title,
+        content=db_post.content,
+        created_at=db_post.created_at,
+        updated_at=db_post.updated_at,
+        owner=db_post.owner.username,
+    )
+
+
+@router.delete("/admin/posts/{post_id}", status_code=204)
+def admin_delete_post(
+    post_id: int,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_session),
+):
+    db_post = db.get(BlogPost, post_id)
+    if not db_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    db.delete(db_post)
+    db.commit()
+    return Response(status_code=204)
+
+
+@router.get("/admin/users", response_model=list[UserOut])
+def admin_list_users(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_session),
+):
+    """Return all registered users for admin dashboard."""
+    users = db.query(User).order_by(User.created_at.desc()).all()
+    return [
+        UserOut(
+            username=u.username,
+            email=u.email,
+            is_admin=u.is_admin,
+            is_donor=u.is_donor,
+        )
+        for u in users
+    ]
+
+
+@router.get("/admin/metrics")
+def admin_metrics(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_session),
+):
+    """Return basic counts for the admin dashboard."""
+    return {
+        "users": db.query(User).count(),
+        "posts": db.query(BlogPost).count(),
+        "donors": db.query(User).filter(User.is_donor.is_(True)).count(),
+    }

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta
+from secrets import token_urlsafe
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..db import get_session
+from ..models import User, PasswordResetToken
+from ..auth import (
+    create_access_token,
+    get_password_hash,
+    authenticate_user,
+    get_current_user,
+)
+from ..utils.email_utils import send_email
+
+router = APIRouter()
+
+
+class UserCreate(BaseModel):
+    username: str
+    email: str
+    password: str
+    is_donor: bool = False
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserOut(BaseModel):
+    username: str
+    email: str
+    is_admin: bool
+    is_donor: bool
+
+
+class ResetRequest(BaseModel):
+    email: str
+
+
+class PasswordReset(BaseModel):
+    token: str
+    new_password: str
+
+
+@router.post("/register", response_model=Token)
+def register(user: UserCreate, db: Session = Depends(get_session)):
+    if db.query(User).filter(
+        (User.username == user.username) | (User.email == user.email)
+    ).first():
+        raise HTTPException(status_code=400, detail="User already exists")
+    db_user = User(
+        username=user.username,
+        email=user.email,
+        hashed_password=get_password_hash(user.password),
+        is_donor=user.is_donor,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    token = create_access_token({"sub": db_user.username})
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/login", response_model=Token)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_session),
+):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    token = create_access_token({"sub": user.username})
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/logout")
+def logout():
+    return {"message": "Logged out"}
+
+
+@router.post("/request-reset")
+def request_password_reset(
+    payload: ResetRequest,
+    db: Session = Depends(get_session),
+):
+    user = db.query(User).filter(User.email == payload.email).first()
+    if not user:
+        return {"message": "If the email exists, a reset link was sent."}
+    token = token_urlsafe(32)
+    expires = datetime.utcnow() + timedelta(hours=1)
+    db_token = PasswordResetToken(user_id=user.id, token=token, expires_at=expires)
+    db.add(db_token)
+    db.commit()
+    send_email(user.email, "Password Reset", f"Your reset token is: {token}")
+    return {"message": "If the email exists, a reset link was sent."}
+
+
+@router.post("/reset-password")
+def reset_password(
+    payload: PasswordReset,
+    db: Session = Depends(get_session),
+):
+    db_token = (
+        db.query(PasswordResetToken)
+        .filter(
+            PasswordResetToken.token == payload.token,
+            PasswordResetToken.used.is_(False),
+        )
+        .first()
+    )
+    if not db_token or db_token.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    user = db.query(User).get(db_token.user_id)
+    user.hashed_password = get_password_hash(payload.new_password)
+    db_token.used = True
+    db.commit()
+    return {"message": "Password updated"}
+
+
+@router.get("/users/me", response_model=UserOut)
+def read_current_user(current_user: User = Depends(get_current_user)):
+    return UserOut(
+        username=current_user.username,
+        email=current_user.email,
+        is_admin=current_user.is_admin,
+        is_donor=current_user.is_donor,
+    )

--- a/backend/routes/blog.py
+++ b/backend/routes/blog.py
@@ -1,0 +1,121 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..db import get_session
+from ..models import BlogPost, User
+from ..auth import get_current_user
+
+router = APIRouter()
+
+
+class BlogPostCreate(BaseModel):
+    title: str
+    content: str
+
+
+class BlogPostOut(BaseModel):
+    id: int
+    title: str
+    content: str
+    created_at: datetime
+    updated_at: datetime
+    owner: str
+
+    class Config:
+        orm_mode = True
+
+
+@router.post("/posts", response_model=BlogPostOut)
+def create_post(
+    post: BlogPostCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+):
+    db_post = BlogPost(title=post.title, content=post.content, owner=current_user)
+    db.add(db_post)
+    db.commit()
+    db.refresh(db_post)
+    return BlogPostOut(
+        id=db_post.id,
+        title=db_post.title,
+        content=db_post.content,
+        created_at=db_post.created_at,
+        updated_at=db_post.updated_at,
+        owner=current_user.username,
+    )
+
+
+@router.get("/posts", response_model=list[BlogPostOut])
+def list_posts(db: Session = Depends(get_session)):
+    posts = db.query(BlogPost).order_by(BlogPost.created_at.desc()).all()
+    return [
+        BlogPostOut(
+            id=p.id,
+            title=p.title,
+            content=p.content,
+            created_at=p.created_at,
+            updated_at=p.updated_at,
+            owner=p.owner.username,
+        )
+        for p in posts
+    ]
+
+
+@router.get("/posts/{post_id}", response_model=BlogPostOut)
+def get_post(post_id: int, db: Session = Depends(get_session)):
+    p = db.query(BlogPost).get(post_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return BlogPostOut(
+        id=p.id,
+        title=p.title,
+        content=p.content,
+        created_at=p.created_at,
+        updated_at=p.updated_at,
+        owner=p.owner.username,
+    )
+
+
+@router.put("/posts/{post_id}", response_model=BlogPostOut)
+def update_post(
+    post_id: int,
+    post: BlogPostCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+):
+    db_post = db.query(BlogPost).get(post_id)
+    if not db_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    if db_post.user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    db_post.title = post.title
+    db_post.content = post.content
+    db.commit()
+    db.refresh(db_post)
+    return BlogPostOut(
+        id=db_post.id,
+        title=db_post.title,
+        content=db_post.content,
+        created_at=db_post.created_at,
+        updated_at=db_post.updated_at,
+        owner=current_user.username,
+    )
+
+
+@router.delete("/posts/{post_id}", status_code=204)
+def delete_post(
+    post_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+):
+    db_post = db.query(BlogPost).get(post_id)
+    if not db_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    if db_post.user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    db.delete(db_post)
+    db.commit()
+    return Response(status_code=204)

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -1,0 +1,86 @@
+import logging
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+
+from ..services.astro import (
+    ProfileRequest,
+    ProfileResponse,
+    compute_vedic_profile,
+    enqueue_profile_job,
+    get_job,
+)
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post("/profile", response_model=ProfileResponse)
+async def get_profile(request: ProfileRequest):
+    """Get complete Vedic astrological profile."""
+    logger.info("Received profile request: %s", request)
+    try:
+        result = compute_vedic_profile(request)
+        logger.info("Profile computation completed")
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/profile/job")
+async def start_profile_job(request: ProfileRequest, background_tasks: BackgroundTasks):
+    """Start background profile computation and return a job ID."""
+    job_id = enqueue_profile_job(request, background_tasks)
+    return {"job_id": job_id}
+
+
+@router.get("/jobs/{job_id}")
+async def get_job_result(job_id: str):
+    """Retrieve status or result for a previously started job."""
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@router.post("/divisional-charts", response_model=ProfileResponse)
+async def get_divisional_charts(request: ProfileRequest):
+    """Return all 16 main divisional charts based on profile input."""
+    logger.info("Received divisional charts request: %s", request)
+    data = compute_vedic_profile(request)
+    logger.info("Divisional charts computation completed")
+    return {"divisionalCharts": data["divisionalCharts"]}
+
+
+@router.post("/dasha", response_model=ProfileResponse)
+async def get_dasha(request: ProfileRequest):
+    """Return Vimshottari dasha with sub-periods."""
+    logger.info("Received dasha request: %s", request)
+    data = compute_vedic_profile(request)
+    logger.info("Dasha computation completed")
+    return {"vimshottariDasha": data["vimshottariDasha"]}
+
+
+@router.post("/yogas", response_model=ProfileResponse)
+async def get_yogas(request: ProfileRequest):
+    """Return all planetary combinations (yogas) in the chart."""
+    logger.info("Received yogas request: %s", request)
+    data = compute_vedic_profile(request)
+    logger.info("Yogas computation completed")
+    return {
+        "yogas": data["yogas"],
+        "analysis": data["analysis"]["yogas"]
+    }
+
+
+@router.post("/strengths", response_model=ProfileResponse)
+async def get_strengths(request: ProfileRequest):
+    """Return planetary and house strengths."""
+    logger.info("Received strengths request: %s", request)
+    data = compute_vedic_profile(request)
+    logger.info("Strengths computation completed")
+    return {
+        "shadbala": data["shadbala"],
+        "bhavaBala": data["bhavaBala"]
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from backend import main
+from backend.routes import profile
 from backend.services import astro
 import fakeredis
 from backend import models, auth
@@ -13,9 +14,9 @@ client = TestClient(main.app)
 
 def _parse_response(data: dict):
     """Helper to parse responses across Pydantic versions."""
-    if hasattr(main.ProfileResponse, "model_validate"):
-        return main.ProfileResponse.model_validate(data)
-    return main.ProfileResponse.parse_obj(data)
+    if hasattr(profile.ProfileResponse, "model_validate"):
+        return profile.ProfileResponse.model_validate(data)
+    return profile.ProfileResponse.parse_obj(data)
 
 
 def test_profile(monkeypatch):
@@ -320,7 +321,7 @@ def test_donor_prompt_report_crud():
 
 
 def test_yogas_route(monkeypatch):
-    monkeypatch.setattr(main, "compute_vedic_profile", lambda req: {
+    monkeypatch.setattr(profile, "compute_vedic_profile", lambda req: {
         "yogas": {"TestYoga": {}},
         "analysis": {"yogas": {"TestYoga": {}}}
     })
@@ -335,7 +336,7 @@ def test_yogas_route(monkeypatch):
 
 
 def test_strengths_route(monkeypatch):
-    monkeypatch.setattr(main, "compute_vedic_profile", lambda req: {
+    monkeypatch.setattr(profile, "compute_vedic_profile", lambda req: {
         "shadbala": {"Sun": 1},
         "bhavaBala": {"1": 10}
     })

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from backend import main, models, auth
+from backend.routes import auth as auth_routes
 from backend.utils import email_utils
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -36,7 +37,7 @@ def test_password_reset_flow(monkeypatch):
         sent["to"] = to
         sent["body"] = body
 
-    monkeypatch.setattr(main, "send_email", fake_send)
+    monkeypatch.setattr(auth_routes, "send_email", fake_send)
 
     with Session() as db:
         user = models.User(


### PR DESCRIPTION
## Summary
- extract authentication, profile, blog, and admin endpoints into `routes` package
- register new routers in a streamlined `main.py`
- update tests to import new modules

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc0950a588320b486b27d3df42e1f