### PR TITLE
Add docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ external backend if you want the frontend to reach it during development.
 add this to .env.local(create the file if it doesnt exist)
 `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`
 
+## Docker Compose
+
+You can run the backend together with Redis and Postgres using Docker
+Compose. Build and start all services with:
+
+```bash
+docker compose up --build
+```
+
+This starts three containers:
+* **backend** – FastAPI app from `backend/Dockerfile` on port 8000
+* **redis** – caching and RQ broker on port 6379
+* **db** – Postgres database on port 5432 stored in the `db_data` volume
+
+The backend container reads environment variables from `backend/.env` so
+adjust `DATABASE_URL` or `CACHE_URL` there as needed.
+
 ## Tests
 
 Install the extra Python packages used during testing and run the frontend and backend tests separately or together using NPM scripts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    volumes:
+      - ./backend:/app
+    env_file:
+      - backend/.env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - redis
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: vedic
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with backend, redis and postgres services
- document how to use Docker Compose in README

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q` *(fails: AttributeError: send_email)*

------
https://chatgpt.com/codex/tasks/task_e_685dc2cef0108320832d992839c84215