### PR TITLE
Add date and time validation

### DIFF
--- a/tests/test_profile_request.py
+++ b/tests/test_profile_request.py
@@ -1,0 +1,16 @@
+from datetime import date, time, timedelta
+import pytest
+
+from backend.services.astro import ProfileRequest
+
+
+def test_profile_request_future_date():
+    tomorrow = date.today() + timedelta(days=1)
+    with pytest.raises(ValueError):
+        ProfileRequest(date=tomorrow, time=time(12, 0), location="Delhi")
+
+
+def test_profile_request_invalid_time():
+    with pytest.raises(ValueError):
+        ProfileRequest(date=date(2020, 1, 1), time=time(23, 59, 1), location="Delhi")
+


### PR DESCRIPTION
## Summary
- reject future dates and times with seconds in `ProfileRequest`
- test validations in new `test_profile_request`

## Testing
- `npm test`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_685dc9cd30308320aead2b25cee04595