### PR TITLE
Add glass-card wrappers

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -5,13 +5,15 @@ import Link from 'next/link';
 
 export default function LandingPage() {
   return (
-    <section className="mb-10 text-center py-20 bg-gradient-to-b from-purple-600 to-blue-600 text-white">
-      <h1 className="text-4xl font-bold mb-4">Cosmic Dharma</h1>
-      <p className="mb-6">Delve into Vedic astrology and discover new insights.</p>
-      <div className="flex justify-center gap-4">
-        <Link href="/login" className="rounded bg-white px-4 py-2 text-blue-600">Login</Link>
-        <a href="#about" className="rounded bg-white px-4 py-2 text-blue-600">Scroll to Read</a>
-      </div>
-    </section>
+    <div className="glass-card mb-10">
+      <section className="text-center py-20 bg-gradient-to-b from-purple-600 to-blue-600 text-white">
+        <h1 className="text-4xl font-bold mb-4">Cosmic Dharma</h1>
+        <p className="mb-6">Delve into Vedic astrology and discover new insights.</p>
+        <div className="flex justify-center gap-4">
+          <Link href="/login" className="rounded bg-white px-4 py-2 text-blue-600">Login</Link>
+          <a href="#about" className="rounded bg-white px-4 py-2 text-blue-600">Scroll to Read</a>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -19,59 +19,61 @@ export interface ProfileFormProps {
 
 export default function ProfileForm({ form, onChange, onSubmit, loading }: ProfileFormProps) {
   return (
-    <form onSubmit={onSubmit} className="mb-6 space-y-4">
-      <p className="help-text">Fill out your birth details to generate a personalized chart.</p>
-      <label>
-        Name:
-        <input
-          name="name"
-          value={form.name}
-          placeholder="Shailesh Tiwari"
-          onChange={onChange}
-          required
-          className="glass-input"
-          title="Your full name for reference"
-        />
-      </label>
-      <label>
-        Date of Birth:
-        <input
-          type="date"
-          name="birthDate"
-          value={form.birthDate}
-          onChange={onChange}
-          required
-          className="glass-input"
-          title="Choose the exact calendar date"
-        />
-      </label>
-      <label>
-        Time of Birth:
-        <input
-          type="time"
-          name="birthTime"
-          value={form.birthTime}
-          onChange={onChange}
-          required
-          className="glass-input"
-          title="Local time of your birth"
-        />
-      </label>
-      <label>
-        Place of Birth:
-        <input
-          name="location"
-          value={form.location}
-          placeholder="Renukoot, India"
-          onChange={onChange}
-          required
-          className="glass-input"
-          title="City or town where you were born"
-        />
-      </label>
-      <button type="submit" disabled={loading} className="glass-button">
-        {loading ? 'Calculating…' : 'Submit'}
-      </button>
-    </form>
+    <div className="glass-card mb-6">
+      <form onSubmit={onSubmit} className="space-y-4">
+        <p className="help-text">Fill out your birth details to generate a personalized chart.</p>
+        <label>
+          Name:
+          <input
+            name="name"
+            value={form.name}
+            placeholder="Shailesh Tiwari"
+            onChange={onChange}
+            required
+            className="glass-input"
+            title="Your full name for reference"
+          />
+        </label>
+        <label>
+          Date of Birth:
+          <input
+            type="date"
+            name="birthDate"
+            value={form.birthDate}
+            onChange={onChange}
+            required
+            className="glass-input"
+            title="Choose the exact calendar date"
+          />
+        </label>
+        <label>
+          Time of Birth:
+          <input
+            type="time"
+            name="birthTime"
+            value={form.birthTime}
+            onChange={onChange}
+            required
+            className="glass-input"
+            title="Local time of your birth"
+          />
+        </label>
+        <label>
+          Place of Birth:
+          <input
+            name="location"
+            value={form.location}
+            placeholder="Renukoot, India"
+            onChange={onChange}
+            required
+            className="glass-input"
+            title="City or town where you were born"
+          />
+        </label>
+        <button type="submit" disabled={loading} className="glass-button">
+          {loading ? 'Calculating…' : 'Submit'}
+        </button>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap landing section in a `glass-card` container
- surround `ProfileForm` with `glass-card` while retaining existing inputs and button

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd9a1ac688320b87bbbaa1c7231de