### PR TITLE
Update README about Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ to launch the frontend and backend. You may run the worker separately if you pre
 npm run worker
 ```
 
+Redis must be running locally before starting the worker. Launch the service
+via Docker Compose or run `redis-server` manually:
+
+```bash
+docker compose up -d redis
+```
+
+Without Redis the worker exits with connection errors.
+
 The frontend runs on port 3000 and uses environment variables to reach the backend on port 8000.
 Create a `.env.local` file if it doesn't exist and set `NEXT_PUBLIC_API_BASE_URL` to the URL of the backend.
 For local development use:


### PR DESCRIPTION
## Summary
- document that Redis must be running before starting the worker
- provide example `docker compose` command and mention failure without Redis

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_685dda818abc8320b873c8961e5c919c