### PR TITLE
Update README with next-pwa fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ curl http://localhost:8000/jobs/<job_id>
 
 When the job completes, the response includes the generated profile data.
 
+### Common issues
+
+If you see `Cannot find module 'next-pwa'` when running `scripts/dev.sh` or
+`npm run dev`, run `npm install --legacy-peer-deps` again to ensure all
+packages are installed.
+
 ## Docker Compose
 
 You can run the backend together with Redis and Postgres using Docker


### PR DESCRIPTION
## Summary
- add troubleshooting section on failing to load `next-pwa`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddb93d8948320b49bfdad3bb3311a