### PR TITLE
Add panchanga support

### DIFF
--- a/backend/panchanga.py
+++ b/backend/panchanga.py
@@ -1,0 +1,149 @@
+"""Basic Panchanga calculations."""
+from __future__ import annotations
+
+from datetime import datetime
+import pytz
+from typing import Dict
+
+from .astro_constants import NAKSHATRA_METADATA
+
+# Names of the 30 tithis
+TITHI_NAMES = [
+    "Shukla Pratipada",
+    "Shukla Dvitiya",
+    "Shukla Tritiya",
+    "Shukla Chaturthi",
+    "Shukla Panchami",
+    "Shukla Shashthi",
+    "Shukla Saptami",
+    "Shukla Ashtami",
+    "Shukla Navami",
+    "Shukla Dashami",
+    "Shukla Ekadashi",
+    "Shukla Dwadashi",
+    "Shukla Trayodashi",
+    "Shukla Chaturdashi",
+    "Purnima",
+    "Krishna Pratipada",
+    "Krishna Dvitiya",
+    "Krishna Tritiya",
+    "Krishna Chaturthi",
+    "Krishna Panchami",
+    "Krishna Shashthi",
+    "Krishna Saptami",
+    "Krishna Ashtami",
+    "Krishna Navami",
+    "Krishna Dashami",
+    "Krishna Ekadashi",
+    "Krishna Dwadashi",
+    "Krishna Trayodashi",
+    "Krishna Chaturdashi",
+    "Amavasya",
+]
+
+# Names of the 27 yogas
+YOGA_NAMES = [
+    "Vishkambha",
+    "Priti",
+    "Ayushman",
+    "Saubhagya",
+    "Shobhana",
+    "Atiganda",
+    "Sukarman",
+    "Dhriti",
+    "Shoola",
+    "Ganda",
+    "Vriddhi",
+    "Dhruva",
+    "Vyaghata",
+    "Harshana",
+    "Vajra",
+    "Siddhi",
+    "Vyatipata",
+    "Variyana",
+    "Parigha",
+    "Shiva",
+    "Siddha",
+    "Sadhya",
+    "Shubha",
+    "Shukla",
+    "Brahma",
+    "Indra",
+    "Vaidhriti",
+]
+
+# Sequence of 60 karanas within a lunar month
+_KARANA_SEQUENCE = (
+    ["Bava", "Balava", "Kaulava", "Taitila", "Garaja", "Vanija", "Vishti"] * 8
+    + ["Shakuni", "Chatushpada", "Naga", "Kimstughna"]
+)
+
+VAARA_NAMES = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+def get_tithi(sun_lon: float, moon_lon: float) -> Dict:
+    """Return tithi details from longitudes."""
+    diff = (moon_lon - sun_lon) % 360
+    index = int(diff // 12)
+    frac = (diff % 12) / 12
+    name = TITHI_NAMES[index]
+    paksha = "Shukla" if index < 15 else "Krishna"
+    return {"index": index + 1, "name": name, "paksha": paksha, "fraction": frac}
+
+
+def get_nakshatra(moon_lon: float) -> Dict:
+    """Return nakshatra and pada for the Moon longitude."""
+    span = 360 / 27
+    index = int(moon_lon % 360 // span)
+    pada = int((moon_lon % span) // (span / 4)) + 1
+    meta = NAKSHATRA_METADATA[index]
+    return {"index": index + 1, "nakshatra": meta["name"], "pada": pada}
+
+
+def get_yoga(sun_lon: float, moon_lon: float) -> Dict:
+    """Return yoga from the sum of longitudes."""
+    total = (sun_lon + moon_lon) % 360
+    span = 360 / 27
+    index = int(total // span)
+    frac = (total % span) / span
+    return {"index": index + 1, "name": YOGA_NAMES[index], "fraction": frac}
+
+
+def get_karana(sun_lon: float, moon_lon: float) -> Dict:
+    """Return karana for the lunar day."""
+    diff = (moon_lon - sun_lon) % 360
+    index = int(diff // 6)
+    frac = (diff % 6) / 6
+    name = _KARANA_SEQUENCE[index]
+    return {"index": index + 1, "name": name, "fraction": frac}
+
+
+def get_vaara(dt: datetime) -> str:
+    """Return weekday name for the given localized datetime."""
+    return VAARA_NAMES[dt.weekday()]
+
+
+def calculate_panchanga(
+    dt: datetime,
+    sun_lon: float,
+    moon_lon: float,
+    timezone: str,
+) -> Dict:
+    """Combine all panchanga elements."""
+    tz = pytz.timezone(timezone)
+    local_dt = dt.astimezone(tz)
+    return {
+        "tithi": get_tithi(sun_lon, moon_lon),
+        "nakshatra": get_nakshatra(moon_lon),
+        "yoga": get_yoga(sun_lon, moon_lon),
+        "karana": get_karana(sun_lon, moon_lon),
+        "vaara": get_vaara(local_dt),
+    }

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -5,6 +5,7 @@ from ..services.astro import (
     ProfileRequest,
     ProfileResponse,
     compute_vedic_profile,
+    compute_panchanga,
     enqueue_profile_job,
     get_job,
 )
@@ -84,3 +85,12 @@ async def get_strengths(request: ProfileRequest):
         "shadbala": data["shadbala"],
         "bhavaBala": data["bhavaBala"]
     }
+
+
+@router.post("/panchanga", response_model=ProfileResponse)
+async def get_panchanga(request: ProfileRequest):
+    """Return traditional panchanga details for the given date."""
+    logger.info("Received panchanga request: %s", request)
+    data = compute_panchanga(request)
+    logger.info("Panchanga computation completed")
+    return {"panchanga": data}

--- a/pages/panchanga.tsx
+++ b/pages/panchanga.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { fetchJson } from '../util/api';
+
+interface PanchangaData {
+  tithi?: { name: string };
+  nakshatra?: { nakshatra: string };
+  yoga?: { name: string };
+  karana?: { name: string };
+  vaara?: string;
+}
+
+export default function PanchangaPage() {
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
+  const [location, setLocation] = useState('');
+  const [data, setData] = useState<PanchangaData | null>(null);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetchJson<{ panchanga: PanchangaData }>('/panchanga', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ date, time, location })
+      });
+      setData(res.panchanga);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <main className="page-wrapper">
+      <h1>Daily Panchanga</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 mb-4">
+        <label>
+          Date:
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} required className="glass-input" />
+        </label>
+        <label>
+          Time:
+          <input type="time" value={time} onChange={e => setTime(e.target.value)} required className="glass-input" />
+        </label>
+        <label>
+          Location:
+          <input value={location} onChange={e => setLocation(e.target.value)} required className="glass-input" />
+        </label>
+        <button type="submit" className="glass-button">Fetch</button>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {data && (
+        <section className="space-y-1">
+          <p><strong>Vaara:</strong> {data.vaara}</p>
+          <p><strong>Tithi:</strong> {data.tithi?.name}</p>
+          <p><strong>Nakshatra:</strong> {data.nakshatra?.nakshatra}</p>
+          <p><strong>Yoga:</strong> {data.yoga?.name}</p>
+          <p><strong>Karana:</strong> {data.karana?.name}</p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/tests/test_panchanga.py
+++ b/tests/test_panchanga.py
@@ -1,0 +1,50 @@
+import pytz
+from datetime import datetime, date, time
+import fakeredis
+from fastapi.testclient import TestClient
+
+from backend import main
+from backend.routes import profile
+from backend.services import astro
+from backend import panchanga
+
+client = TestClient(main.app)
+
+
+def test_tithi_calculation():
+    res = panchanga.get_tithi(0.0, 13.0)
+    assert res["index"] == 2
+    assert "Dvitiya" in res["name"]
+
+
+def test_karana_calculation():
+    res = panchanga.get_karana(0.0, 15.0)
+    assert res["name"] == "Kaulava"
+
+
+def test_vaara():
+    dt = pytz.timezone("UTC").localize(datetime(2023, 8, 28))
+    assert panchanga.get_vaara(dt) == "Monday"
+
+
+def test_compute_panchanga(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(astro, "_CACHE", fake)
+    astro.clear_profile_cache()
+    monkeypatch.setattr(astro, "geocode_location", lambda loc: (10.0, 20.0, "UTC"))
+    monkeypatch.setattr(astro, "get_birth_info", lambda **k: {"jd_ut": 0, "sidereal_offset": 0})
+    monkeypatch.setattr(astro, "calculate_planets", lambda *a, **k: [
+        {"name": "Sun", "longitude": 0},
+        {"name": "Moon", "longitude": 15},
+    ])
+    req = astro.ProfileRequest(date=date(2020,1,1), time=time(12,0), location="Delhi")
+    data = astro.compute_panchanga(req)
+    assert data["tithi"]["name"].startswith("Shukla")
+    assert data["vaara"] == "Wednesday"
+
+
+def test_panchanga_route(monkeypatch):
+    monkeypatch.setattr(profile, "compute_panchanga", lambda req: {"vaara": "Friday"})
+    resp = client.post("/panchanga", json={"date": "2020-01-01", "time": "12:00:00", "location": "Delhi"})
+    assert resp.status_code == 200
+    assert resp.json()["panchanga"] == {"vaara": "Friday"}


### PR DESCRIPTION
## Summary
- implement basic panchanga calculations
- add compute_panchanga service and API route
- provide a simple frontend page to query daily panchanga
- test new algorithms and endpoint

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddd1072a88320811a31d8a731df0d