### PR TITLE
Add env setup step in dev script

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Ensure backend/.env exists, copying from the example if available
+if [ ! -f backend/.env ] && [ -f backend/.env.example ]; then
+  cp backend/.env.example backend/.env
+  echo "Created backend/.env from backend/.env.example. Please adjust the values as needed."
+fi
+
 # Verify required commands are available
 for cmd in node npm python3; do
   if ! command -v "$cmd" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- ensure `backend/.env` is present when running `scripts/dev.sh`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685de2143d94832092fd5c8e9535bb27