### PR TITLE
Improve Redis startup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ password to finish the process.
 
 ## Running the application
 
-Run the helper script during the first setup. It verifies that **Node.js 18+** and **Python 3** are available, installs dependencies if required and then starts the frontend, backend and worker:
+Run the helper script during the first setup. It verifies that **Node.js 18+** and **Python 3** are available, installs dependencies if required and then starts the frontend, backend and worker. The script also checks for a local Redis instance and attempts to start one automatically:
 
 ```bash
 ./scripts/dev.sh
@@ -115,8 +115,10 @@ to launch the frontend and backend. You may run the worker separately if you pre
 npm run worker
 ```
 
-Redis must be running locally before starting the worker. Launch the service
-via Docker Compose or run `redis-server` manually:
+Redis must be running locally before starting the worker. `scripts/dev.sh`
+tries to launch Redis automatically using Docker Compose or `redis-server`.
+Ensure one of these tools is installed for the automatic startup to succeed.
+If the script fails or you prefer to manage Redis yourself, start it manually:
 
 ```bash
 docker compose up -d redis

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -40,9 +40,10 @@ pip install -r backend/requirements.txt
 pip install -r backend/requirements-dev.txt
 
 # Test connectivity to Redis before starting services. If Redis isn't running,
-# attempt to start it with Docker Compose and wait a few seconds for it to
-# accept connections. When Docker Compose is unavailable, fall back to
-# `redis-server` (daemonized) and clean it up on exit.
+# attempt to start it automatically. Docker Compose is preferred and the script
+# falls back to a daemonized `redis-server` when available. One of these tools
+# must be installed for the automatic startup to succeed. Any `redis-server`
+# process started by this script will be cleaned up on exit.
 REDIS_URL="redis://localhost:6379"
 if [ -f backend/.env ]; then
   val=$(grep -E '^REDIS_URL=' backend/.env | cut -d '=' -f2- | tr -d '\r')
@@ -101,7 +102,7 @@ if ! check_redis "$REDIS_URL"; then
         exit 1
       fi
     else
-      echo "Error: Redis is not running and Docker Compose is unavailable." >&2
+      echo "Error: Redis is not running and neither Docker Compose nor redis-server was found." >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
## Summary
- explain automatic Redis start via `scripts/dev.sh`
- clarify that Docker or `redis-server` is required for this
- update error message in `scripts/dev.sh`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de3354c0483209e49773aee690c7e