### PR TITLE
Add sign name helper and improve chart outputs

### DIFF
--- a/backend/analysis.py
+++ b/backend/analysis.py
@@ -4,6 +4,7 @@ Comprehensive Vedic analysis module with proper interpretations.
 """
 from datetime import date
 from .astro_constants import NAKSHATRA_METADATA
+from .utils.signs import get_sign_name
 
 # Cache for analyses
 _CACHE = {}
@@ -257,13 +258,17 @@ def interpret_divisional_charts(dcharts, planets=None):
             # Check 5th lord placement
             analysis['children_indication'] = "Examine 5th house lord for children matters"
         
-        # Add planet distribution
-        analysis['placements'] = mapping
+        # Add planet distribution with sign names
+        analysis['placements'] = {
+            planet: get_sign_name(sign) for planet, sign in mapping.items()
+        }
 
         # Simple distribution count per sign
         dist = {}
         for sign in mapping.values():
-            dist[sign] = dist.get(sign, 0) + 1
+            name = get_sign_name(sign)
+            if name:
+                dist[name] = dist.get(name, 0) + 1
         analysis['distribution'] = dist
 
         summary[chart] = analysis

--- a/backend/services/astro.py
+++ b/backend/services/astro.py
@@ -31,6 +31,7 @@ from backend.shadbala import calculate_shadbala, calculate_bhava_bala
 from backend.ashtakavarga import calculate_ashtakavarga
 from backend.analysis import full_analysis
 from backend import panchanga
+from backend.utils.signs import get_sign_name
 
 CONFIG = load_config()
 logger = logging.getLogger(__name__)
@@ -246,9 +247,13 @@ def compute_vedic_profile(request: ProfileRequest) -> dict:
     analysis_results['bhavaBala'] = bhava_bala
     analysis_results['vargottamaPlanets'] = vargottama
 
+    named_planets = [
+        {**p, "sign": get_sign_name(p["sign"])} for p in planets
+    ]
+
     result = {
         "birthInfo": {**binfo, "latitude": lat, "longitude": lon, "timezone": tz},
-        "planetaryPositions": planets,
+        "planetaryPositions": named_planets,
         "vimshottariDasha": dashas,
         "nakshatra": nak,
         "houses": houses,

--- a/backend/utils/signs.py
+++ b/backend/utils/signs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from backend.astro_constants import RASHI_METADATA
+
 
 def get_sign_lord(sign_num: int) -> str | None:
     """Return the ruling planet of a given zodiac sign."""
@@ -20,4 +22,11 @@ def get_sign_lord(sign_num: int) -> str | None:
         12: "Jupiter",
     }
     return lords.get(sign_num)
+
+
+def get_sign_name(sign_num: int) -> str | None:
+    """Return the English name of the zodiac sign number."""
+    if 1 <= sign_num <= 12:
+        return RASHI_METADATA[sign_num - 1]["name"]
+    return None
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -38,7 +38,7 @@ def test_interpret_divisional_charts():
     charts = {'D1': {'Sun': 1, 'Moon': 1}}
     res = interpret_divisional_charts(charts)
     assert 'D1' in res
-    assert res['D1']['distribution'][1] == 2
+    assert res['D1']['distribution']['Aries'] == 2
 
 
 def test_full_analysis():

--- a/tests/test_signs.py
+++ b/tests/test_signs.py
@@ -1,0 +1,21 @@
+import pytest
+from backend.utils.signs import get_sign_name
+
+
+def test_get_sign_name_all():
+    expected = [
+        "Aries",
+        "Taurus",
+        "Gemini",
+        "Cancer",
+        "Leo",
+        "Virgo",
+        "Libra",
+        "Scorpio",
+        "Sagittarius",
+        "Capricorn",
+        "Aquarius",
+        "Pisces",
+    ]
+    for idx, name in enumerate(expected, start=1):
+        assert get_sign_name(idx) == name


### PR DESCRIPTION
## Summary
- implement `get_sign_name` to map sign numbers using `RASHI_METADATA`
- convert planetary and divisional chart outputs to show sign names
- add tests for sign name mappings
- update existing analysis test to expect named signs

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de70da3648320a302f6ed2849fda2