### PR TITLE
Fix dev script redis URL detection

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -46,7 +46,7 @@ pip install -r backend/requirements-dev.txt
 # process started by this script will be cleaned up on exit.
 REDIS_URL="redis://localhost:6379"
 if [ -f backend/.env ]; then
-  val=$(grep -E '^REDIS_URL=' backend/.env | cut -d '=' -f2- | tr -d '\r')
+  val=$(grep -E '^REDIS_URL=' backend/.env | cut -d '=' -f2- | tr -d '\r' || true)
   if [ -z "$val" ]; then
     val=$(grep -E '^CACHE_URL=' backend/.env | cut -d '=' -f2- | tr -d '\r')
   fi


### PR DESCRIPTION
## Summary
- prevent `set -e` failures when `REDIS_URL` is missing in `.env`
- keep fallback to `CACHE_URL`

## Testing
- `npm test`
- `PYTHONPATH=. pytest`
- `bash scripts/dev.sh` (fails to start Redis)

------
https://chatgpt.com/codex/tasks/task_e_685de86f699c83208ccac24bd7cde45f