### PR TITLE
Add REDIS_URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ reads these environment variables:
 * `HOUSE_SYSTEM` – astrological house system (`whole_sign` by default).
 * `CACHE_ENABLED` – enable or disable caching.
 * `CACHE_URL` – Redis URL used for the profile cache.
-* `REDIS_URL` – connection string for Redis used by the background job queue.
+* `REDIS_URL` – connection string for Redis used by the background job queue
+  (defaults to `redis://localhost:6379/1`).
 * `CACHE_TTL` – cache lifetime in seconds.
 * `SMTP_SERVER` – hostname of your SMTP server for sending email.
 * `SMTP_PORT` – port of the SMTP server (`587` by default).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
-# Copy this file to .env and adjust values for local development or deployment
+# Copy this file to .env and adjust values for local development or deployment.
+# Uncomment and edit REDIS_URL if background jobs use a different Redis instance.
 SECRET_KEY=change-me
 DATABASE_URL=sqlite:///./app.db
 ACCESS_TOKEN_EXPIRE_MINUTES=30
@@ -8,6 +9,7 @@ NODE_TYPE=mean
 HOUSE_SYSTEM=whole_sign
 CACHE_ENABLED=true
 CACHE_URL=redis://localhost:6379/1
+#REDIS_URL=redis://localhost:6379/1
 SMTP_SERVER=
 SMTP_PORT=587
 SMTP_USER=


### PR DESCRIPTION
## Summary
- document optional `REDIS_URL` in backend `.env.example`
- note default for `REDIS_URL` in README

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de9c4b5888320a60fa72fb85af3a6