### PR TITLE
Improve Redis startup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,18 @@ npm run worker
 ```
 
 Redis must be running locally before starting the worker. `scripts/dev.sh`
-tries to launch Redis automatically using Docker Compose or `redis-server`.
-Ensure one of these tools is installed for the automatic startup to succeed.
-If the script cannot start Redis, it continues without the worker. Start Redis
-manually (for example with `docker compose up -d redis`) and run `npm run
-worker` in a separate terminal to enable background tasks. You may also launch
-Redis yourself and rerun the script.
+tries to launch Redis automatically using Docker Compose (`docker compose` or
+`docker-compose`) or `redis-server`. Ensure one of these tools is installed for
+the automatic startup to succeed. If the script cannot start Redis, it continues
+without the worker. Start Redis manually (for example with `docker compose up -d
+redis` or `docker-compose up -d redis`) and run `npm run worker` in a separate
+terminal to enable background tasks. You may also launch Redis yourself and
+rerun the script.
 
 ```bash
 docker compose up -d redis
+# or
+docker-compose up -d redis
 ```
 
 Without Redis the worker exits with connection errors.
@@ -167,6 +170,8 @@ Compose. Build and start all services with:
 
 ```bash
 docker compose up --build
+# or
+docker-compose up --build
 ```
 
 This starts three containers:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -69,10 +69,19 @@ except Exception:
 EOF
 }
 
+DOCKER_COMPOSE_CMD=""
+if command -v docker >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE_CMD="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE_CMD="docker-compose"
+  fi
+fi
+
 if ! check_redis "$REDIS_URL"; then
   echo "Redis is not running; attempting to start via Docker Compose..." >&2
-  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-    docker compose up -d redis
+  if [ -n "$DOCKER_COMPOSE_CMD" ]; then
+    $DOCKER_COMPOSE_CMD up -d redis
     for _ in {1..5}; do
       sleep 1
       if check_redis "$REDIS_URL"; then
@@ -106,7 +115,7 @@ if ! check_redis "$REDIS_URL"; then
       fi
     else
       echo "Warning: Redis is not running and neither Docker Compose nor redis-server was found." >&2
-      echo "Start Redis manually (e.g., 'docker compose up -d redis') to enable the worker." >&2
+      echo "Start Redis manually (e.g., 'docker compose up -d redis' or 'docker-compose up -d redis') to enable the worker." >&2
       RUN_WORKER=0
     fi
   fi


### PR DESCRIPTION
## Summary
- support `docker-compose` when starting Redis
- clarify automatic Redis launch in docs

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_685df0ec28448320a826098afccd9ff6