### PR TITLE
Prevent npx prompt during setup

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -135,8 +135,8 @@ trap cleanup EXIT
 # Start Next.js and the FastAPI backend. Launch the background worker only if
 # Redis is available.
 if [ "$RUN_WORKER" -eq 1 ]; then
-  npx concurrently --kill-others-on-fail "npm run dev" "npm run worker"
+  npx --yes concurrently --kill-others-on-fail "npm run dev" "npm run worker"
 else
-  npx concurrently --kill-others-on-fail "npm run dev"
+  npx --yes concurrently --kill-others-on-fail "npm run dev"
   echo "Background worker disabled due to missing Redis." >&2
 fi


### PR DESCRIPTION
## Summary
- avoid interactive prompt from `npx concurrently`

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df5b1bff88320a833bb8f93831cee