### PR TITLE
Add labels and autocomplete to auth forms

### DIFF
--- a/components/LoginPage.test.tsx
+++ b/components/LoginPage.test.tsx
@@ -13,6 +13,16 @@ vi.mock('next/router', () => ({
   useRouter: () => ({ push: vi.fn() })
 }));
 
+test('renders labels for inputs', () => {
+  render(
+    <ToastProvider>
+      <LoginPage />
+    </ToastProvider>
+  );
+  expect(screen.getByLabelText(/username/i)).toBeDefined();
+  expect(screen.getByLabelText(/password/i)).toBeDefined();
+});
+
 test('submits credentials via apiFetch', async () => {
   const fetchMock = apiFetch as any;
   fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ access_token: 't' }) });
@@ -21,8 +31,8 @@ test('submits credentials via apiFetch', async () => {
       <LoginPage />
     </ToastProvider>
   );
-  fireEvent.change(screen.getByPlaceholderText(/username/i), { target: { value: 'u' } });
-  fireEvent.change(screen.getByPlaceholderText(/password/i), { target: { value: 'p' } });
+  fireEvent.change(screen.getAllByPlaceholderText(/username/i)[0], { target: { value: 'u' } });
+  fireEvent.change(screen.getAllByPlaceholderText(/password/i)[0], { target: { value: 'p' } });
   fireEvent.click(screen.getAllByRole('button', { name: /login/i })[0]);
   expect(apiFetch).toHaveBeenCalledWith('login', expect.any(Object));
 });

--- a/components/RegisterPage.test.tsx
+++ b/components/RegisterPage.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import RegisterPage from '../pages/register';
+import ToastProvider from './ToastProvider';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}));
+
+vi.mock('../util/api', () => ({
+  default: vi.fn()
+}));
+
+test('renders labels for register form', () => {
+  render(
+    <ToastProvider>
+      <RegisterPage />
+    </ToastProvider>
+  );
+  expect(screen.getByLabelText(/username/i)).toBeDefined();
+  expect(screen.getByLabelText(/email/i)).toBeDefined();
+  expect(screen.getByLabelText(/password/i)).toBeDefined();
+});

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -34,16 +34,22 @@ export default function LoginPage() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2">
       <h2 className="text-xl font-semibold">Login</h2>
+      <label htmlFor="username">Username</label>
       <input
+        id="username"
         name="username"
+        autoComplete="username"
         value={form.username}
         onChange={handleChange}
         placeholder="Username"
         className="border rounded p-2"
       />
+      <label htmlFor="password">Password</label>
       <input
+        id="password"
         name="password"
         type="password"
+        autoComplete="current-password"
         value={form.password}
         onChange={handleChange}
         placeholder="Password"

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import apiFetch from '../util/api';
 import { useToast } from '../components/ToastProvider';
@@ -35,24 +35,33 @@ export default function RegisterPage() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2">
       <h2 className="text-xl font-semibold">Register</h2>
+      <label htmlFor="username">Username</label>
       <input
+        id="username"
         name="username"
+        autoComplete="username"
         value={form.username}
         onChange={handleChange}
         placeholder="Username"
         className="border rounded p-2"
       />
+      <label htmlFor="email">Email</label>
       <input
+        id="email"
         name="email"
         type="email"
+        autoComplete="email"
         value={form.email}
         onChange={handleChange}
         placeholder="Email"
         className="border rounded p-2"
       />
+      <label htmlFor="password">Password</label>
       <input
+        id="password"
         name="password"
         type="password"
+        autoComplete="new-password"
         value={form.password}
         onChange={handleChange}
         placeholder="Password"


### PR DESCRIPTION
## Summary
- link login inputs with labels and add autocomplete attributes
- link register inputs with labels and add autocomplete attributes
- verify labels render on login and register pages

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ead141f0483208dbdcfc88c4789a8