### PR TITLE
Add PageHead helper and meta tags

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -1,0 +1,31 @@
+import Head from 'next/head';
+import React from 'react';
+
+export interface PageHeadProps {
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImage?: string;
+  ogUrl?: string;
+}
+
+export default function PageHead({
+  title,
+  description,
+  ogTitle,
+  ogDescription,
+  ogImage,
+  ogUrl
+}: PageHeadProps) {
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {ogTitle && <meta property="og:title" content={ogTitle} />}
+      {ogDescription && <meta property="og:description" content={ogDescription} />}
+      {ogImage && <meta property="og:image" content={ogImage} />}
+      {ogUrl && <meta property="og:url" content={ogUrl} />}
+    </Head>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,22 @@
 import LandingPage from '../components/LandingPage';
+import PageHead from '../components/PageHead';
 
 export default function HomePage() {
   return (
-    <main className="page-wrapper">
-      <LandingPage />
-      <section id="about" className="mt-10">
-        <h2>About Cosmic Dharma</h2>
-        <p>Read our latest posts and learn about Vedic astrology.</p>
-      </section>
-    </main>
+    <>
+      <PageHead
+        title="Cosmic Dharma"
+        description="Explore Vedic astrology insights and our latest posts."
+        ogTitle="Cosmic Dharma"
+        ogDescription="Discover Vedic astrology and read the Cosmic Dharma blog."
+      />
+      <main className="page-wrapper">
+        <LandingPage />
+        <section id="about" className="mt-10">
+          <h2>About Cosmic Dharma</h2>
+          <p>Read our latest posts and learn about Vedic astrology.</p>
+        </section>
+      </main>
+    </>
   );
 }

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import apiFetch from '../../util/api';
 import { useToast } from '../../components/ToastProvider';
+import PageHead from '../../components/PageHead';
 
 interface BlogPost {
   id: number;
@@ -30,9 +31,17 @@ export default function PostViewPage() {
   if (!post) return <p>Loading...</p>;
 
   return (
-    <article>
-      <h2>{post.title}</h2>
-      <ReactMarkdown>{post.content}</ReactMarkdown>
-    </article>
+    <>
+      <PageHead
+        title={post.title}
+        description={`${post.content.slice(0, 150)}...`}
+        ogTitle={post.title}
+        ogDescription={post.content.slice(0, 150)}
+      />
+      <article>
+        <h2>{post.title}</h2>
+        <ReactMarkdown>{post.content}</ReactMarkdown>
+      </article>
+    </>
   );
 }

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -1,9 +1,18 @@
 import PostList from '../../components/PostList';
+import PageHead from '../../components/PageHead';
 
 export default function PostListPage() {
   return (
-    <div>
-      <PostList />
-    </div>
+    <>
+      <PageHead
+        title="Cosmic Dharma Blog"
+        description="Browse recent articles from Cosmic Dharma."
+        ogTitle="Cosmic Dharma Blog"
+        ogDescription="Latest articles on Vedic astrology."
+      />
+      <div>
+        <PostList />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- create a `PageHead` component wrapping `next/head`
- add page metadata to the home page and blog pages

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_685eaec2eb7483209b55fb9de63d0dbe