### PR TITLE
Load ReactMde dynamically

### DIFF
--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -11,7 +11,12 @@ interface User {
   id: number;
   username: string;
 }
-import ReactMde from 'react-mde';
+import dynamic from 'next/dynamic';
+
+const ReactMde = dynamic(() => import('react-mde'), {
+  ssr: false,
+  loading: () => <p>Loading editor...</p>
+});
 import ReactMarkdown from 'react-markdown';
 import { Bar } from 'react-chartjs-2';
 import {

--- a/pages/editor.tsx
+++ b/pages/editor.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react';
-import ReactMde from 'react-mde';
+import dynamic from 'next/dynamic';
+
+const ReactMde = dynamic(() => import('react-mde'), {
+  ssr: false,
+  loading: () => <p>Loading editor...</p>
+});
 import 'react-mde/lib/styles/css/react-mde-all.css';
 import ReactMarkdown from 'react-markdown';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- lazy load `react-mde` using `next/dynamic`
- show a loading message while the editor module loads

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685eb7c955f883208ccd93c163e6a4af