### PR TITLE
Add accessibility to toast provider

### DIFF
--- a/components/LoginPage.test.tsx
+++ b/components/LoginPage.test.tsx
@@ -48,5 +48,6 @@ test('shows error toast on failed login', async () => {
   fireEvent.change(screen.getAllByPlaceholderText(/username/i)[0], { target: { value: 'u' } });
   fireEvent.change(screen.getAllByPlaceholderText(/password/i)[0], { target: { value: 'p' } });
   fireEvent.click(screen.getAllByRole('button', { name: /login/i })[0]);
-  await screen.findByText(/login failed/i);
+  const alert = await screen.findByRole('alert');
+  expect(alert.textContent).toMatch(/login failed/i);
 });

--- a/components/PostList.test.tsx
+++ b/components/PostList.test.tsx
@@ -16,5 +16,6 @@ test('shows error toast when fetch fails', async () => {
       <PostList />
     </ToastProvider>
   );
-  await screen.findByText(/failed to load posts/i);
+  const alert = await screen.findByRole('alert');
+  expect(alert.textContent).toMatch(/failed to load posts/i);
 });

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useState } from 'react';
 interface Toast {
   id: number;
   message: string;
+  visible: boolean;
 }
 
 const ToastContext = createContext<(msg: string) => void>(() => {});
@@ -16,7 +17,10 @@ export default function ToastProvider({ children }: { children: React.ReactNode 
 
   const addToast = (message: string) => {
     const id = Date.now();
-    setToasts(t => [...t, { id, message }]);
+    setToasts(t => [...t, { id, message, visible: true }]);
+    setTimeout(() => {
+      setToasts(t => t.map(toast => toast.id === id ? { ...toast, visible: false } : toast));
+    }, 2500);
     setTimeout(() => {
       setToasts(t => t.filter(toast => toast.id !== id));
     }, 3000);
@@ -29,7 +33,9 @@ export default function ToastProvider({ children }: { children: React.ReactNode 
         {toasts.map(t => (
           <div
             key={t.id}
-            className="bg-red-600 text-white px-3 py-2 rounded shadow"
+            role="alert"
+            aria-live="assertive"
+            className={`bg-red-600 text-white px-3 py-2 rounded shadow transition-all duration-500 transform ${t.visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
           >
             {t.message}
           </div>


### PR DESCRIPTION
## Summary
- add fade animations and ARIA alerts for toast notifications
- verify toast role in LoginPage and PostList tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebb1dde9c83209d9b375fdf426e49