### PR TITLE
Add loading skeleton to profile page

### DIFF
--- a/components/ProfileSkeleton.tsx
+++ b/components/ProfileSkeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function ProfileSkeleton() {
+  return (
+    <section data-testid="profile-skeleton">
+      <div className="glass-card mb-6 animate-pulse h-24" />
+      <div className="glass-card mb-6 animate-pulse h-16" />
+      <div className="glass-card mb-6 animate-pulse h-16" />
+      <div className="glass-card mb-6 animate-pulse h-32" />
+      <div className="glass-card mb-6 animate-pulse h-32" />
+      <div className="glass-card mb-6 animate-pulse h-24" />
+      <div className="glass-card mb-6 animate-pulse h-40 flex justify-center items-center">
+        <div className="h-8 w-8 border-4 border-gray-300 border-t-transparent rounded-full animate-spin" />
+      </div>
+    </section>
+  );
+}

--- a/pages/profile.test.tsx
+++ b/pages/profile.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import ProfilePage from './profile';
+import { fetchJson } from '../util/api';
+
+vi.mock('../util/api', () => ({
+  fetchJson: vi.fn(),
+}));
+
+const fillForm = () => {
+  fireEvent.change(screen.getByPlaceholderText(/Shailesh Tiwari/i), {
+    target: { value: 'John' },
+  });
+  fireEvent.change(screen.getByLabelText(/Date of Birth/i), {
+    target: { value: '2000-01-01' },
+  });
+  fireEvent.change(screen.getByLabelText(/Time of Birth/i), {
+    target: { value: '12:00' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Renukoot, India/i), {
+    target: { value: 'Delhi' },
+  });
+};
+
+test('shows skeleton while loading profile', async () => {
+  (fetchJson as unknown as vi.Mock).mockResolvedValueOnce({ job_id: '1' });
+  render(<ProfilePage />);
+  fillForm();
+  fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
+  expect(await screen.findByTestId('profile-skeleton')).toBeDefined();
+});

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { fetchJson } from '../util/api';
 import ProfileForm from '../components/ProfileForm';
 import BasicInfo from '../components/BasicInfo';
@@ -8,6 +8,7 @@ import PlanetTable from '../components/PlanetTable';
 import HouseAnalysis from '../components/HouseAnalysis';
 import DashaTable from '../components/DashaTable';
 import DashaChart from '../components/DashaChart';
+import ProfileSkeleton from '../components/ProfileSkeleton';
 
 interface ProfileFormData {
   name: string;
@@ -84,6 +85,7 @@ export default function ProfilePage() {
       <h1>Vedic Astrology</h1>
       <ProfileForm form={form} onChange={handleChange} onSubmit={handleSubmit} loading={loading} />
       {error && <p className="text-red-500">{error}</p>}
+      {loading && !profile && <ProfileSkeleton />}
       {profile && (
         <section>
           <BasicInfo birth={{ ...profile.birthInfo, ...form }} />


### PR DESCRIPTION
## Summary
- show skeleton placeholders while a profile loads
- add a spinning progress indicator
- test loading state on the profile page

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebcf32c888320a911e5613d91ff51