### PR TITLE
Add theme toggle

### DIFF
--- a/components/Navbar.test.tsx
+++ b/components/Navbar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import { expect, test, vi, afterEach } from 'vitest';
+import { expect, test, vi, afterEach, beforeAll } from 'vitest';
 import Navbar from './Navbar';
+import ThemeProvider from './ThemeProvider';
 
 let router = { pathname: '/', push: vi.fn() };
 vi.mock('next/router', () => ({
@@ -21,10 +22,28 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+beforeAll(() => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+
+function renderNav() {
+  render(
+    <ThemeProvider>
+      <Navbar />
+    </ThemeProvider>
+  );
+}
+
 test('shows login link when logged out', () => {
   setToken(null);
   router.pathname = '/';
-  render(<Navbar />);
+  renderNav();
   expect(screen.getByRole('link', { name: /home/i })).toBeDefined();
   expect(screen.getByRole('link', { name: /posts/i })).toBeDefined();
   expect(screen.getByRole('link', { name: /dashboard/i })).toBeDefined();
@@ -35,7 +54,7 @@ test('shows login link when logged out', () => {
 test('shows logout button when logged in', async () => {
   setToken('t');
   router.pathname = '/';
-  render(<Navbar />);
+  renderNav();
   await screen.findByRole('button', { name: /logout/i });
   expect(screen.getByRole('button', { name: /logout/i })).toBeDefined();
 });
@@ -43,9 +62,16 @@ test('shows logout button when logged in', async () => {
 test('highlights the active page', () => {
   setToken(null);
   router.pathname = '/posts';
-  render(<Navbar />);
+  renderNav();
   const posts = screen.getByRole('link', { name: /posts/i });
   expect(posts.getAttribute('aria-current')).toBe('page');
   const home = screen.getByRole('link', { name: /home/i });
   expect(home.getAttribute('aria-current')).toBeNull();
+});
+
+test('shows theme toggle button', () => {
+  setToken(null);
+  router.pathname = '/';
+  renderNav();
+  expect(screen.getByRole('button', { name: /toggle theme/i })).toBeDefined();
 });

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useTheme } from './ThemeProvider';
 
 export default function Navbar() {
   const router = useRouter();
   const [authed, setAuthed] = useState(false);
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
@@ -62,6 +64,11 @@ export default function Navbar() {
               Login
             </Link>
           )}
+        </li>
+        <li>
+          <button onClick={toggleTheme} aria-label="toggle theme">
+            {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+          </button>
         </li>
       </ul>
     </nav>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  // initialize from localStorage or system preference
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  // apply class and persist
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.classList.toggle('light', theme === 'light');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,13 +3,16 @@ import type { AppProps } from 'next/app';
 import Navbar from '../components/Navbar';
 import ToastProvider from '../components/ToastProvider';
 import StarryBackground from '../components/StarryBackground';
+import ThemeProvider from '../components/ThemeProvider';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <ToastProvider>
-      <StarryBackground />
-      <Navbar />
-      <Component {...pageProps} />
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <StarryBackground />
+        <Navbar />
+        <Component {...pageProps} />
+      </ToastProvider>
+    </ThemeProvider>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,16 @@
   --foreground: #171717;
 }
 
+.light {
+  --background: #ffffff;
+  --foreground: #171717;
+}
+
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -13,7 +23,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not(.light):not(.dark) {
     --background: #0a0a0a;
     --foreground: #ededed;
   }


### PR DESCRIPTION
## Summary
- make a ThemeProvider with localStorage persistence
- add light/dark CSS classes
- include ThemeProvider in `_app`
- update Navbar with toggle and tests

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ec18d8394832095538debd94b610a