### PR TITLE
Add favicon and PWA icons

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,6 +5,7 @@ export default function Document() {
     <Html>
       <Head>
         <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" href="/favicon.svg" />
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#310c4b"/>
+  <polygon points="256,60 306,200 460,200 334,300 380,452 256,360 132,452 178,300 52,200 206,200" fill="#9b5de5"/>
+</svg>

--- a/public/icon-192x192.svg
+++ b/public/icon-192x192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#310c4b"/>
+  <polygon points="256,60 306,200 460,200 334,300 380,452 256,360 132,452 178,300 52,200 206,200" fill="#9b5de5"/>
+</svg>

--- a/public/icon-512x512.svg
+++ b/public/icon-512x512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#310c4b"/>
+  <polygon points="256,60 306,200 460,200 334,300 380,452 256,360 132,452 178,300 52,200 206,200" fill="#9b5de5"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,5 +9,17 @@
   "theme_color": "#310c4b",
   "background_color": "#12091d",
   "lang": "en",
-  "categories": ["education", "lifestyle"]
+  "categories": ["education", "lifestyle"],
+  "icons": [
+    {
+      "src": "/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- generate new favicon and PWA icon images using SVG
- reference icons from manifest.json

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ecb5a3f5c8320bf4acb89581c68b0