### PR TITLE
Add offline fallback for PWA

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,19 @@ export default withPWA({
   runtimeCaching: [
     ...runtimeCaching,
     {
+      urlPattern: ({ request }) => request.mode === "navigate",
+      handler: "NetworkFirst",
+      options: {
+        cacheName: "html-cache",
+        networkTimeoutSeconds: 10,
+        plugins: [
+          {
+            handlerDidError: async () => caches.match("/offline.html"),
+          },
+        ],
+      },
+    },
+    {
       urlPattern: ({ url }) => url.pathname.startsWith("/api"),
       handler: "NetworkFirst",
       options: {

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      font-family: Arial, sans-serif;
+      text-align: center;
+      padding: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>You are offline</h1>
+    <p>Please check your internet connection and try again.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure next-pwa runtime caching to serve `offline.html`
- add an offline fallback page

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed5c285888320bbf0da8c3e05934f