### PR TITLE
Add example env file for frontend

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Copy this file to .env.local and adjust values for local development
+# Base URL of the FastAPI backend used by Next.js
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ reads these environment variables:
 * `SMTP_PASS` – SMTP password for the above user.
 * `FROM_EMAIL` – default sender address for outgoing mail.
 
-For the Next.js frontend, create `.env.local` and set `NEXT_PUBLIC_API_BASE_URL`
-to the URL of your backend. During local development this is usually
-`http://localhost:8000`.
+For the Next.js frontend, copy `.env.local.example` to `.env.local` and set
+`NEXT_PUBLIC_API_BASE_URL` to the URL of your backend. During local development
+this is usually `http://localhost:8000`.
 
 To seed the database with demo accounts and posts run from the repository root:
 
@@ -134,7 +134,7 @@ docker-compose up -d redis
 Without Redis the worker exits with connection errors.
 
 The frontend runs on port 3000 and uses environment variables to reach the backend on port 8000.
-Create a `.env.local` file if it doesn't exist and set `NEXT_PUBLIC_API_BASE_URL` to the URL of the backend.
+Copy `.env.local.example` to `.env.local` if it doesn't exist and set `NEXT_PUBLIC_API_BASE_URL` to the URL of the backend.
 For local development use:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `.env.local.example` with default API URL
- document new example file in README setup instructions

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef34e88508320bab1511d26bbc1f2