### PR TITLE
Fix quoting for start services

### DIFF
--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -519,9 +519,9 @@ start_services() {
     echo $$ > "$PID_FILE"
     
     # Prepare startup command
-    local services="npm run dev"
+    local services="\"npm run dev\""
     if [ $WORKER_ENABLED -eq 1 ]; then
-        services="$services\" \"npm run worker"
+        services="$services \"npm run worker\""
     fi
     
     echo -e "\n${BOLD}${GREEN}${ROCKET} Launching Cosmic Dharma...${RESET}\n"


### PR DESCRIPTION
## Summary
- properly quote npm commands when starting services

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f01a7b6ac8320aadbbfc8adfacff1