### PR TITLE
Remove viewport from Document

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 // pages/_app.tsx
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import ToastProvider from '../components/ToastProvider';
@@ -22,11 +23,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }, []);
 
   return (
-    <ThemeProvider>
-      <ToastProvider>
-        <div className="min-h-screen relative">
-          <StarryBackground />
-          <Header />
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <ThemeProvider>
+        <ToastProvider>
+          <div className="min-h-screen relative">
+            <StarryBackground />
+            <Header />
           
           <AnimatePresence mode="wait" initial={false}>
             <motion.main
@@ -42,8 +47,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           </AnimatePresence>
           
           <Footer />
-        </div>
-      </ToastProvider>
-    </ThemeProvider>
+          </div>
+        </ToastProvider>
+      </ThemeProvider>
+    </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,7 +7,6 @@ export default function Document() {
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" href="/favicon.svg" />
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
           name="description"
           content="Cosmic Dharma offers cosmic insights through Vedic astrology."


### PR DESCRIPTION
## Summary
- remove viewport tag from custom Document
- place viewport meta tag in `_app.tsx`

## Testing
- `npm test` *(fails: 4 failed, 12 passed)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: swisseph)*

------
https://chatgpt.com/codex/tasks/task_e_6861137f0140832097c727fc475e7d04