### PR TITLE
Update Next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,10 @@ import runtimeCaching from "next-pwa/cache";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
+  allowedDevOrigins: [
+    "http://127.0.0.1:3000",
+    "http://localhost:3000",
+  ],
 };
 
 export default withPWA({


### PR DESCRIPTION
## Summary
- add `allowedDevOrigins` to the Next.js config so local origins are allowed

## Testing
- `npm test` *(fails: 4 failed, 21 passed)*
- `PYTHONPATH=. pytest` *(fails: 1 failed, 68 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686115f9757c8320b3f6c8d182ac0490