### PR TITLE
Add basic lagna test

### DIFF
--- a/tests/test_birth_info.py
+++ b/tests/test_birth_info.py
@@ -2,7 +2,8 @@ import datetime
 import pytest
 import swisseph as swe
 
-from backend.birth_info import get_birth_info, AYANAMSHA_MAP
+from backend.birth_info import get_birth_info, get_lagna, AYANAMSHA_MAP
+from backend.astro_constants import RASHI_METADATA
 
 
 def test_ayanamsha_and_house(monkeypatch):
@@ -80,3 +81,14 @@ def test_unknown_house_system():
             'UTC',
             house_system='invalid',
         )
+
+
+def test_get_lagna_basic(monkeypatch):
+    """get_lagna should return metadata for the rising sign."""
+    def fake_houses(jd, lat, lon, hsys=b'P'):
+        return ([45.0] + [0] * 11, [0] * 8)
+
+    monkeypatch.setattr(swe, 'houses', fake_houses)
+
+    res = get_lagna(0.0, 0.0, 0.0)
+    assert res == RASHI_METADATA[1]


### PR DESCRIPTION
## Summary
- verify house system and ascendant values in get_lagna
- add `test_get_lagna_basic` in `tests/test_birth_info.py`

## Testing
- `npm test` *(fails: 4 failed, 21 passed)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686119aed150832081ae606bb1ea9d79