### PR TITLE
Add test_app fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import sqlalchemy
+
+from backend import main, models, auth
+
+
+@pytest.fixture
+def test_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    TestingSession = sessionmaker(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+
+    def override():
+        db = TestingSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    overrides = main.app.dependency_overrides.copy()
+    main.app.dependency_overrides[main.get_session] = override
+    main.app.dependency_overrides[auth.get_session] = override
+    client = TestClient(main.app)
+    try:
+        yield client, TestingSession
+    finally:
+        main.app.dependency_overrides = overrides
+

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,35 +1,8 @@
-from fastapi.testclient import TestClient
-from backend import main, models, auth
+from backend import models, auth
 from backend.routes import auth as auth_routes
-from backend.utils import email_utils
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-import sqlalchemy
 
-
-def setup_test_app():
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=sqlalchemy.pool.StaticPool,
-    )
-    TestingSession = sessionmaker(bind=engine)
-    models.Base.metadata.create_all(bind=engine)
-
-    def override():
-        db = TestingSession()
-        try:
-            yield db
-        finally:
-            db.close()
-
-    main.app.dependency_overrides[main.get_session] = override
-    main.app.dependency_overrides[auth.get_session] = override
-    return TestClient(main.app), TestingSession
-
-
-def test_password_reset_flow(monkeypatch):
-    client, Session = setup_test_app()
+def test_password_reset_flow(test_app, monkeypatch):
+    client, Session = test_app
 
     sent = {}
 


### PR DESCRIPTION
## Summary
- add shared `test_app` fixture for FastAPI tests
- refactor login and password reset tests to use fixture

## Testing
- `npm test` *(fails: 4 failed, 12 passed)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611cf051dc832085dddd634fc57e0f