### PR TITLE
Add tests for ProfileRequest aliases

### DIFF
--- a/tests/test_profile_request.py
+++ b/tests/test_profile_request.py
@@ -14,3 +14,26 @@ def test_profile_request_invalid_time():
     with pytest.raises(ValueError):
         ProfileRequest(date=date(2020, 1, 1), time=time(23, 59, 1), location="Delhi")
 
+
+def test_profile_request_alias_fields():
+    req = ProfileRequest(
+        date=date(2020, 1, 1),
+        time=time(6, 30),
+        location="Delhi",
+        lunar_node="true",
+        ayanamsa="kp",
+        house_system="equal",
+    )
+
+    assert req.birth_date == date(2020, 1, 1)
+    assert req.birth_time == time(6, 30)
+    assert req.location == "Delhi"
+    assert req.node_type == "true"
+    assert req.ayanamsa == "kp"
+    assert req.house_system == "equal"
+
+
+def test_profile_request_time_with_seconds_string():
+    with pytest.raises(ValueError):
+        ProfileRequest(date=date(2020, 1, 1), time="23:59:01", location="Delhi")
+


### PR DESCRIPTION
## Summary
- extend coverage in `tests/test_profile_request.py` for alias fields
- check that invalid time string with seconds errors

## Testing
- `npm test` *(fails: 4 failed, 12 passed)*
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68611f6778248320990e0149c350faf9