### PR TITLE
Add theme toggle test

### DIFF
--- a/components/DashboardPage.test.tsx
+++ b/components/DashboardPage.test.tsx
@@ -42,7 +42,7 @@ test('renders post list for donors', async () => {
   render(<DashboardPage />);
   await screen.findAllByText('Dashboard');
   fireEvent.click(screen.getAllByText('Posts')[0]);
-  await screen.findByText(/blog posts/i);
+  await screen.findByText(/cosmic insights/i);
 });
 
 test('renders admin dashboard for admins', async () => {

--- a/components/LandingPage.test.tsx
+++ b/components/LandingPage.test.tsx
@@ -5,9 +5,9 @@ import LandingPage from './LandingPage';
 
 test('renders hero and navigation links', () => {
   render(<LandingPage />);
-  expect(screen.getByRole('heading', { name: /cosmic/i })).toBeDefined();
-  const login = screen.getByRole('link', { name: /login/i });
-  expect(login.getAttribute('href')).toBe('/login');
-  const read = screen.getByRole('link', { name: /scroll to read/i });
-  expect(read.getAttribute('href')).toBe('#about');
+  expect(screen.getByRole('heading', { name: /cosmic dharma/i })).toBeDefined();
+  const chart = screen.getByRole('link', { name: /get your chart/i });
+  expect(chart.getAttribute('href')).toBe('/profile');
+  const blog = screen.getByRole('link', { name: /explore blog/i });
+  expect(blog.getAttribute('href')).toBe('/posts');
 });

--- a/components/Navbar.test.tsx
+++ b/components/Navbar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { expect, test, vi, afterEach, beforeAll } from 'vitest';
 import Navbar from './Navbar';
 import ThemeProvider from './ThemeProvider';
@@ -74,4 +74,14 @@ test('shows theme toggle button', () => {
   router.pathname = '/';
   renderNav();
   expect(screen.getByRole('button', { name: /toggle theme/i })).toBeDefined();
+});
+
+test('toggle theme button', () => {
+  setToken(null);
+  router.pathname = '/';
+  renderNav();
+  const button = screen.getByRole('button', { name: /toggle theme/i });
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  fireEvent.click(button);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
 });

--- a/components/ProfileForm.test.tsx
+++ b/components/ProfileForm.test.tsx
@@ -11,6 +11,8 @@ test('handles input and submit', () => {
   render(<ProfileForm form={filled} onChange={handleChange} onSubmit={handleSubmit} loading={false} />);
   fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'New' } });
   expect(handleChange).toHaveBeenCalled();
-  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+  fireEvent.click(screen.getByRole('button', { name: /generate chart/i }));
   expect(handleSubmit).toHaveBeenCalled();
 });

--- a/pages/profile.test.tsx
+++ b/pages/profile.test.tsx
@@ -29,6 +29,6 @@ test('shows skeleton while loading profile', async () => {
   (fetchJson as unknown as vi.Mock).mockResolvedValueOnce({ job_id: '1' });
   render(<ProfilePage />);
   fillForm();
-  fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
+  fireEvent.click(screen.getByRole('button', { name: /generate chart/i }));
   expect(await screen.findByTestId('profile-skeleton')).toBeDefined();
 });


### PR DESCRIPTION
## Summary
- cover theme toggle behavior in `Navbar`
- update tests for UI text changes

## Testing
- `npm test`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68611fbc06a08320b95d8907038cd9e6