### PR TITLE
Add API tests

### DIFF
--- a/util/api.test.ts
+++ b/util/api.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchJson } from './api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchJson', () => {
+  it('throws error when response JSON is invalid', async () => {
+    const res = new Response('invalid', { status: 200 });
+    vi.spyOn(global, 'fetch').mockResolvedValue(res as any);
+    await expect(fetchJson('/test')).rejects.toThrow('Invalid JSON response');
+  });
+
+  it('uses detail message from non-ok response', async () => {
+    const body = JSON.stringify({ detail: 'bad' });
+    const res = new Response(body, { status: 400, statusText: 'Bad' });
+    vi.spyOn(global, 'fetch').mockResolvedValue(res as any);
+    await expect(fetchJson('/test')).rejects.toThrow('bad');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,7 +4,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['components/**/*.test.{js,jsx,ts,tsx}', 'pages/**/*.test.{js,jsx,ts,tsx}'],
+    include: [
+      'components/**/*.test.{js,jsx,ts,tsx}',
+      'pages/**/*.test.{js,jsx,ts,tsx}',
+      'util/**/*.test.{js,jsx,ts,tsx}'
+    ],
     coverage: {
       reporter: ['text', 'html'],
       reportsDirectory: 'coverage'


### PR DESCRIPTION
## Summary
- add tests for `fetchJson`
- enable `util` test directory in Vitest config

## Testing
- `npm test` *(fails: 4 failed | 13 passed)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611fb3804c8320aefdcfebc981c48f