### PR TITLE
Fix venv activation path

### DIFF
--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -393,9 +393,16 @@ setup_python_environment() {
         print_success "Virtual environment created"
     fi
     
-    # Activate virtual environment
+    # Activate virtual environment - support Unix and Windows layouts
     echo -e "  ${DIM}Activating virtual environment...${RESET}"
-    source backend/venv/bin/activate
+    if [ -f backend/venv/bin/activate ]; then
+        source backend/venv/bin/activate
+    elif [ -f backend/venv/Scripts/activate ]; then
+        source backend/venv/Scripts/activate
+    else
+        print_error "Virtual environment not found. Run 'python3 -m venv backend/venv' to create it."
+        exit 1
+    fi
     
     # Upgrade pip first
     echo -e "  ${DIM}Upgrading pip...${RESET}"


### PR DESCRIPTION
## Summary
- improve setup step to handle Windows-style venv layout

## Testing
- `npm test` *(fails: unknown test, components/PostList.test.tsx shows error toast when fetch fails, etc.)*
- `PYTHONPATH=. pytest -q` *(fails: tests fail with 404 status)*

------
https://chatgpt.com/codex/tasks/task_e_686153ed424883208466f1c4ec150924