### PR TITLE
Add .gitattributes to enforce Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- normalize line endings for shell scripts to fix `/usr/bin/env: ‘bash\r’: No such file or directory` on Windows

## Testing
- `npm test` *(fails: 3 failed, 14 passed)*
- `PYTHONPATH=. pytest -q` *(fails: several tests failing with 404 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861568bb83c8320aa429a8567a87b8c