### PR TITLE
Remove local Redis configuration

### DIFF
--- a/.redis.conf
+++ b/.redis.conf
@@ -1,7 +1,0 @@
-port 6379
-bind 127.0.0.1
-daemonize yes
-pidfile /mnt/c/Users/23shl/Desktop/Coding/Side-Projects/CosmicDharma/.redis.pid
-dir /mnt/c/Users/23shl/Desktop/Coding/Side-Projects/CosmicDharma
-save ""
-appendonly no

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ the automatic startup to succeed. If the script cannot start Redis, it continues
 without the worker. Start Redis manually (for example with `docker compose up -d
 redis` or `docker-compose up -d redis`) and run `npm run worker` in a separate
 terminal to enable background tasks. You may also launch Redis yourself and
-rerun the script.
+rerun the script. If you use `redis-server`, copy `redis.conf.example` to
+`.redis.conf` and update the `pidfile` and `dir` paths to suit your environment.
 
 ```bash
 docker compose up -d redis

--- a/redis.conf.example
+++ b/redis.conf.example
@@ -1,0 +1,16 @@
+# Example Redis configuration for local development
+# Copy this file to `.redis.conf` and adjust paths as needed.
+
+port 6379
+bind 127.0.0.1
+
+# Run Redis as a daemon so npm scripts can start it automatically
+daemonize yes
+
+# Update these paths for your environment
+pidfile /path/to/project/.redis.pid
+dir /path/to/project
+
+# Disable persistence for temporary local data
+save ""
+appendonly no


### PR DESCRIPTION
## Summary
- remove `.redis.conf` containing absolute paths
- provide a redis config template `redis.conf.example`
- document how to use the example when running `redis-server`

## Testing
- `npm test` *(fails: unknown test and component tests)*
- `PYTHONPATH=. pytest -q` *(fails: several endpoint tests return 404)*

------
https://chatgpt.com/codex/tasks/task_e_687bfe81e0ac8320996c94f22da526b0