### PR TITLE
Add custom 500 error page

### DIFF
--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import Link from 'next/link';
+
+export default function ServerErrorPage() {
+  return (
+    <main className="page-wrapper flex flex-col items-center justify-center gap-4 py-20 text-center">
+      <h1 className="text-3xl font-semibold">Something Went Wrong</h1>
+      <p>Sorry, an unexpected error has occurred.</p>
+      <Link href="/" className="text-blue-600 underline">
+        Go back home
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple `pages/500.tsx` to display a user-friendly message when a server error occurs

## Testing
- `npm test` *(fails: 3 test files, 4 tests)*
- `PYTHONPATH=. pytest -q` *(fails during tests)*
- `npm run build` *(fails: type errors during linting)*

------
https://chatgpt.com/codex/tasks/task_e_687c1ef48ee08320a6d978955f057c56